### PR TITLE
Fix Windows version

### DIFF
--- a/packetinterface.h
+++ b/packetinterface.h
@@ -22,6 +22,8 @@
 #include <QTimer>
 #include <QVector>
 
+#include <stdint.h>
+
 class PacketInterface : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
No int8_t type on Windows without stdint.h