### PR TITLE
Updating README to include qt5 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@ A Qt gui to control and debug my custom BLDC controller. A complete description 
 
 Quick build instructions for Ubuntu:
 
-1. sudo apt-get install qtcreator qt-sdk libudev-dev libqt5serialport5-dev
+1. `sudo apt-get install qtcreator qt-sdk libudev-dev libqt5serialport5-dev`
 
-2. qmake
+2. `qmake -qt=qt5`
 
-3. make
+3. `make clean && make`
+
+4. Start BLDC-tool `sudo ./BLDC_Tool`
 
 Windows and OS X builds available :
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Quick build instructions for Ubuntu:
 
 3. `make clean && make`
 
-4. Start BLDC-tool `sudo ./BLDC_Tool`
+4. Allow for serial access without using sudo: `sudo adduser $USER dialout`
+
+5. Restart for access changes to take effect `sudo reboot now`
+
+6. Start BLDC-tool from inside of the built repo `./BLDC_Tool`
 
 Windows and OS X builds available :
 


### PR DESCRIPTION
This is required for the build of BLDC-Tool. Otherwise, lots of errors occur.
