### PR TITLE
Made window scrollable in height.

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -22,227 +22,3065 @@
   <widget class="QWidget" name="centralWidget">
    <layout class="QHBoxLayout" name="horizontalLayout">
     <item>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
-      <item>
-       <widget class="QTabWidget" name="tabWidget">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>1</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="tabPosition">
-         <enum>QTabWidget::North</enum>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="tab_11">
-         <attribute name="title">
-          <string>Motor Configuration</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_31">
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+      </property>
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents_5">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>1306</width>
+         <height>836</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_54">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
-           <widget class="QTabWidget" name="tabWidget_4">
+           <widget class="QTabWidget" name="tabWidget">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>1</verstretch>
+             </sizepolicy>
+            </property>
             <property name="tabPosition">
-             <enum>QTabWidget::West</enum>
+             <enum>QTabWidget::North</enum>
             </property>
             <property name="currentIndex">
              <number>0</number>
             </property>
-            <widget class="QWidget" name="tab_12">
+            <widget class="QWidget" name="tab_11">
              <attribute name="title">
-              <string>Motor</string>
+              <string>Motor Configuration</string>
              </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_24">
+             <layout class="QVBoxLayout" name="verticalLayout_31">
               <item>
-               <widget class="QGroupBox" name="groupBox_29">
-                <property name="title">
-                 <string>Motor Type</string>
+               <widget class="QTabWidget" name="tabWidget_4">
+                <property name="tabPosition">
+                 <enum>QTabWidget::West</enum>
                 </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_34">
-                 <item>
-                  <widget class="QRadioButton" name="mcconfTypeBldcButton">
-                   <property name="text">
-                    <string>BLDC</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="mcconfTypeDcButton">
-                   <property name="text">
-                    <string>DC</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="mcconfTypeFocButton">
-                   <property name="text">
-                    <string>FOC</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_15">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QGridLayout" name="gridLayout_24">
-                <item row="0" column="0">
-                 <widget class="QGroupBox" name="groupBox_8">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="title">
-                   <string>Current Limits</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_18">
-                   <item>
-                    <layout class="QGridLayout" name="gridLayout_9">
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="label_19">
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <widget class="QWidget" name="tab_12">
+                 <attribute name="title">
+                  <string>Motor</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_24">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_29">
+                    <property name="title">
+                     <string>Motor Type</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_34">
+                     <item>
+                      <widget class="QRadioButton" name="mcconfTypeBldcButton">
                        <property name="text">
-                        <string>Batt min (regen)</string>
+                        <string>BLDC</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
                        </property>
                       </widget>
                      </item>
-                     <item row="4" column="0">
-                      <widget class="QLabel" name="label_20">
+                     <item>
+                      <widget class="QRadioButton" name="mcconfTypeDcButton">
                        <property name="text">
-                        <string>Absolute max</string>
+                        <string>DC</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimCurrentInMinBox">
-                       <property name="suffix">
-                        <string> A</string>
+                     <item>
+                      <widget class="QRadioButton" name="mcconfTypeFocButton">
+                       <property name="text">
+                        <string>FOC</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_15">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QGridLayout" name="gridLayout_24">
+                    <item row="0" column="0">
+                     <widget class="QGroupBox" name="groupBox_8">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>Current Limits</string>
+                      </property>
+                      <layout class="QHBoxLayout" name="horizontalLayout_18">
+                       <item>
+                        <layout class="QGridLayout" name="gridLayout_9">
+                         <item row="3" column="0">
+                          <widget class="QLabel" name="label_19">
+                           <property name="text">
+                            <string>Batt min (regen)</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="4" column="0">
+                          <widget class="QLabel" name="label_20">
+                           <property name="text">
+                            <string>Absolute max</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimCurrentInMinBox">
+                           <property name="suffix">
+                            <string> A</string>
+                           </property>
+                           <property name="minimum">
+                            <double>-200.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>0.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="0">
+                          <widget class="QLabel" name="label_18">
+                           <property name="text">
+                            <string>Batt max</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_17">
+                           <property name="text">
+                            <string>Motor min (regen)</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="4" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimCurrentAbsMaxBox">
+                           <property name="suffix">
+                            <string> A</string>
+                           </property>
+                           <property name="maximum">
+                            <double>240.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimCurrentMinBox">
+                           <property name="suffix">
+                            <string> A</string>
+                           </property>
+                           <property name="minimum">
+                            <double>-200.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>0.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimCurrentInMaxBox">
+                           <property name="suffix">
+                            <string> A</string>
+                           </property>
+                           <property name="maximum">
+                            <double>200.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_16">
+                           <property name="text">
+                            <string>Motor max</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimCurrentMaxBox">
+                           <property name="suffix">
+                            <string> A</string>
+                           </property>
+                           <property name="maximum">
+                            <double>200.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="0">
+                          <widget class="QCheckBox" name="mcconfLimCurrentSlowAbsMaxBox">
+                           <property name="text">
+                            <string>Slow absolute max</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QGroupBox" name="groupBox_9">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>RPM Limits (BLDC Only)</string>
+                      </property>
+                      <layout class="QHBoxLayout" name="horizontalLayout_19">
+                       <item>
+                        <layout class="QGridLayout" name="gridLayout_10">
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_21">
+                           <property name="text">
+                            <string>Min ERPM</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmBox">
+                           <property name="maximum">
+                            <double>200000.000000000000000</double>
+                           </property>
+                           <property name="singleStep">
+                            <double>100.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmFbrakeBox">
+                           <property name="maximum">
+                            <double>100000.000000000000000</double>
+                           </property>
+                           <property name="singleStep">
+                            <double>100.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMinErpmBox">
+                           <property name="minimum">
+                            <double>-200000.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>0.000000000000000</double>
+                           </property>
+                           <property name="singleStep">
+                            <double>100.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="0">
+                          <widget class="QLabel" name="label_22">
+                           <property name="text">
+                            <string>Max ERPM</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="0">
+                          <widget class="QLabel" name="label_23">
+                           <property name="text">
+                            <string>Max ERPM at full brake</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QCheckBox" name="mcconfLimErpmLimitNegTorqueBox">
+                           <property name="text">
+                            <string>Limit ERPM with negative torque</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="0">
+                          <spacer name="verticalSpacer_11">
+                           <property name="orientation">
+                            <enum>Qt::Vertical</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>20</width>
+                             <height>40</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item row="4" column="0">
+                          <widget class="QLabel" name="label_62">
+                           <property name="text">
+                            <string>Max ERPM at full brake in current control mode</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="4" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmFbrakeCcBox">
+                           <property name="maximum">
+                            <double>100000.000000000000000</double>
+                           </property>
+                           <property name="singleStep">
+                            <double>100.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QGroupBox" name="groupBox_27">
+                      <property name="title">
+                       <string>Temperature Limits</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_23">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_57">
+                         <property name="text">
+                          <string>MOSFET Start</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfLimTempFetStartBox">
+                         <property name="suffix">
+                          <string> °C</string>
+                         </property>
+                         <property name="minimum">
+                          <double>-100.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>300.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>5.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_58">
+                         <property name="text">
+                          <string>MOSFET End</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfLimTempFetEndBox">
+                         <property name="suffix">
+                          <string> °C</string>
+                         </property>
+                         <property name="minimum">
+                          <double>-100.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>300.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>5.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_59">
+                         <property name="text">
+                          <string>Motor Start</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfLimTempMotorStartBox">
+                         <property name="suffix">
+                          <string> °C</string>
+                         </property>
+                         <property name="minimum">
+                          <double>-100.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>300.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>5.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_60">
+                         <property name="text">
+                          <string>Motor End</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfLimTempMotorEndBox">
+                         <property name="suffix">
+                          <string> °C</string>
+                         </property>
+                         <property name="minimum">
+                          <double>-100.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>300.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>5.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QGroupBox" name="groupBox_10">
+                      <property name="title">
+                       <string>Voltage Limits</string>
+                      </property>
+                      <layout class="QHBoxLayout" name="horizontalLayout_20">
+                       <item>
+                        <layout class="QGridLayout" name="gridLayout_11">
+                         <item row="2" column="0">
+                          <widget class="QLabel" name="label_86">
+                           <property name="text">
+                            <string>Battery cutoff start</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_25">
+                           <property name="text">
+                            <string>Maximum input voltage</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_24">
+                           <property name="text">
+                            <string>Minimum input voltage</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMinVinBox">
+                           <property name="suffix">
+                            <string> V</string>
+                           </property>
+                           <property name="minimum">
+                            <double>6.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>60.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimMaxVinBox">
+                           <property name="suffix">
+                            <string> V</string>
+                           </property>
+                           <property name="minimum">
+                            <double>6.000000000000000</double>
+                           </property>
+                           <property name="maximum">
+                            <double>60.000000000000000</double>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="0">
+                          <widget class="QLabel" name="label_87">
+                           <property name="text">
+                            <string>Battery cutoff end</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="2" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimBatteryCutStartBox">
+                           <property name="suffix">
+                            <string> V</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QDoubleSpinBox" name="mcconfLimBatteryCutEndBox">
+                           <property name="suffix">
+                            <string> V</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_38">
+                    <property name="title">
+                     <string>Other Limits</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_36">
+                     <item row="0" column="0" rowspan="2" colspan="2">
+                      <widget class="QLabel" name="label_83">
+                       <property name="text">
+                        <string>Minimum duty cycle</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2" rowspan="2">
+                      <widget class="QLabel" name="label_84">
+                       <property name="text">
+                        <string>Maximum duty cycle</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3" rowspan="2">
+                      <widget class="QDoubleSpinBox" name="mcconfLimMaxDutyBox">
+                       <property name="decimals">
+                        <number>3</number>
                        </property>
                        <property name="minimum">
-                        <double>-200.000000000000000</double>
+                        <double>0.010000000000000</double>
                        </property>
                        <property name="maximum">
-                        <double>0.000000000000000</double>
+                        <double>0.950000000000000</double>
                        </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="label_18">
-                       <property name="text">
-                        <string>Batt max</string>
+                       <property name="singleStep">
+                        <double>0.010000000000000</double>
                        </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_17">
-                       <property name="text">
-                        <string>Motor min (regen)</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimCurrentAbsMaxBox">
-                       <property name="suffix">
-                        <string> A</string>
-                       </property>
-                       <property name="maximum">
-                        <double>240.000000000000000</double>
+                       <property name="value">
+                        <double>0.950000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="1" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimCurrentMinBox">
-                       <property name="suffix">
-                        <string> A</string>
+                      <widget class="QDoubleSpinBox" name="mcconfLimMinDutyBox">
+                       <property name="decimals">
+                        <number>3</number>
                        </property>
                        <property name="minimum">
-                        <double>-200.000000000000000</double>
+                        <double>0.005000000000000</double>
                        </property>
                        <property name="maximum">
-                        <double>0.000000000000000</double>
+                        <double>0.500000000000000</double>
                        </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimCurrentInMaxBox">
-                       <property name="suffix">
-                        <string> A</string>
-                       </property>
-                       <property name="maximum">
-                        <double>200.000000000000000</double>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_16">
-                       <property name="text">
-                        <string>Motor max</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimCurrentMaxBox">
-                       <property name="suffix">
-                        <string> A</string>
-                       </property>
-                       <property name="maximum">
-                        <double>200.000000000000000</double>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="0">
-                      <widget class="QCheckBox" name="mcconfLimCurrentSlowAbsMaxBox">
-                       <property name="text">
-                        <string>Slow absolute max</string>
+                       <property name="singleStep">
+                        <double>0.005000000000000</double>
                        </property>
                       </widget>
                      </item>
                     </layout>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QGroupBox" name="groupBox_9">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="title">
-                   <string>RPM Limits (BLDC Only)</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_19">
-                   <item>
-                    <layout class="QGridLayout" name="gridLayout_10">
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_21">
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_4">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>17</width>
+                      <height>172</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_13">
+                 <attribute name="title">
+                  <string>BLDC</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_23">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_34">
+                    <property name="title">
+                     <string>Sensor Mode</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_43">
+                     <item>
+                      <widget class="QRadioButton" name="mcconfSensorModeSensorlessButton">
                        <property name="text">
-                        <string>Min ERPM</string>
+                        <string>Sensorless</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="mcconfSensorModeSensoredButton">
+                       <property name="text">
+                        <string>Sensored</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="mcconfSensorModeHybridButton">
+                       <property name="text">
+                        <string>Hybrid</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_20">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_21">
+                    <item>
+                     <widget class="QGroupBox" name="mcconfSlBox">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>Sensorless</string>
+                      </property>
+                      <property name="checkable">
+                       <bool>false</bool>
+                      </property>
+                      <property name="checked">
+                       <bool>false</bool>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_12">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_26">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important for startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>Min ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSlMinErpmBox">
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_30">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For phase advance, not so important&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>BR ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSlBrErpmBox">
+                         <property name="maximum">
+                          <double>200000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>100.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_29">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For phase advance, not so important&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>Phase advance at BR ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSlIntLimScaleBrBox">
+                         <property name="maximum">
+                          <double>1.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.100000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_61">
+                         <property name="text">
+                          <string>Max brake current at dir change</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSlMaxFbCurrBox">
+                         <property name="maximum">
+                          <double>300.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_16">
+                      <property name="title">
+                       <string>Sensorless - Commutation Mode</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_46">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_100">
+                         <property name="text">
+                          <string>Comm Mode</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QRadioButton" name="mcconfCommIntButton">
+                         <property name="text">
+                          <string>Integrate</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QRadioButton" name="mcconfCommDelayButton">
+                         <property name="text">
+                          <string>Delay</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_28">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important. The detection function below can be used to determine this parameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>Integrator Limit</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1" colspan="2">
+                        <widget class="QDoubleSpinBox" name="mcconfSlIntLimBox">
+                         <property name="maximum">
+                          <double>2000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>1.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_27">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important for startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>Int Limit Min ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1" colspan="2">
+                        <widget class="QDoubleSpinBox" name="mcconfSlMinErpmIlBox">
+                         <property name="maximum">
+                          <double>10000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_41">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important. The detection function below can be used to determine this parameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="text">
+                          <string>BEMF Coupling</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1" colspan="2">
+                        <widget class="QDoubleSpinBox" name="mcconfSlBemfKBox">
+                         <property name="maximum">
+                          <double>5000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_12">
+                    <property name="title">
+                     <string>Hall Sensors</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_20">
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_22">
+                       <item>
+                        <widget class="QLabel" name="label_31">
+                         <property name="text">
+                          <string>Table</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab0Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab1Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab2Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab3Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab4Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab5Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab6Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSpinBox" name="mcconfHallTab7Box">
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>6</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLabel" name="label_32">
+                         <property name="text">
+                          <string>Sensorless ERPM (hybrid mode)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QDoubleSpinBox" name="mcconfHallSlErpmBox">
+                         <property name="maximum">
+                          <double>200000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                         <property name="value">
+                          <double>0.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <spacer name="horizontalSpacer_8">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>40</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_7">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>209</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_11">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="title">
+                     <string>Detect Parameters</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_24">
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_47">
+                       <item row="0" column="0">
+                        <widget class="QPushButton" name="mcconfDetectMotorParamButton">
+                         <property name="text">
+                          <string>Start detection</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <spacer name="verticalSpacer_5">
+                         <property name="orientation">
+                          <enum>Qt::Vertical</enum>
+                         </property>
+                         <property name="sizeType">
+                          <enum>QSizePolicy::Preferred</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>20</width>
+                           <height>13</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QPushButton" name="mcconfDetectApplyButton">
+                         <property name="text">
+                          <string>Apply</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_7">
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfDetectCurrentBox">
+                         <property name="suffix">
+                          <string> A</string>
+                         </property>
+                         <property name="value">
+                          <double>6.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_44">
+                         <property name="text">
+                          <string>Min ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfDetectErpmBox">
+                         <property name="decimals">
+                          <number>1</number>
+                         </property>
+                         <property name="minimum">
+                          <double>10.000000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>10000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                         <property name="value">
+                          <double>600.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_42">
+                         <property name="toolTip">
+                          <string>The duty cycle at which the BEMF coupling is measured. A value between 0.03 and 0.15 usually works.</string>
+                         </property>
+                         <property name="text">
+                          <string>Low duty</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfDetectLowDutyBox">
+                         <property name="maximum">
+                          <double>0.400000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                         <property name="value">
+                          <double>0.050000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_43">
+                         <property name="text">
+                          <string>Current</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <widget class="QTextBrowser" name="mcconfDetectResultBrowser">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="html">
+                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;Detection results will be printed here.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_24">
+                 <attribute name="title">
+                  <string>FOC</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_29">
+                  <item>
+                   <layout class="QGridLayout" name="gridLayout_42">
+                    <item row="0" column="0">
+                     <widget class="QGroupBox" name="groupBox_39">
+                      <property name="title">
+                       <string>General</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_39">
+                       <item row="4" column="3">
+                        <widget class="QDoubleSpinBox" name="mcconfFocEncoderRatioBox">
+                         <property name="prefix">
+                          <string>Rat: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>500.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_89">
+                         <property name="text">
+                          <string>Current Control</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocCurrKpBox">
+                         <property name="prefix">
+                          <string>Kp: </string>
+                         </property>
+                         <property name="decimals">
+                          <number>4</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="3">
+                        <widget class="QDoubleSpinBox" name="mcconfFocCurrKiBox">
+                         <property name="prefix">
+                          <string>Ki: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="0">
+                        <widget class="QLabel" name="label_92">
+                         <property name="text">
+                          <string>Encoder</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocEncoderOffsetBox">
+                         <property name="prefix">
+                          <string>Ofs: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>360.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_101">
+                         <property name="text">
+                          <string>Sensor Mode</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="3">
+                        <widget class="QCheckBox" name="mcconfFocEncoderInvertedBox">
+                         <property name="text">
+                          <string>Invert Encoder</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2" colspan="2">
+                        <layout class="QHBoxLayout" name="horizontalLayout_26">
+                         <item>
+                          <widget class="QRadioButton" name="mcconfFocModeEncoderButton">
+                           <property name="text">
+                            <string>Encoder</string>
+                           </property>
+                           <property name="checked">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QRadioButton" name="mcconfFocModeHallButton">
+                           <property name="text">
+                            <string>Hall</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QRadioButton" name="mcconfFocModeSensorlessButton">
+                           <property name="text">
+                            <string>Sensorless</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                       <item row="5" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocSlErpmBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ERPM above which the hall sensors or encoder will be ignored and only the observer is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="maximum">
+                          <double>200000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="0">
+                        <widget class="QLabel" name="label_96">
+                         <property name="text">
+                          <string>Sensorless ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QGroupBox" name="groupBox_41">
+                      <property name="title">
+                       <string>General (cont)</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_40">
+                       <item row="7" column="0">
+                        <widget class="QLabel" name="label_104">
+                         <property name="text">
+                          <string>Openloop RPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocPllKpBox">
+                         <property name="prefix">
+                          <string>Kp: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="6" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocDutyDownrampKiBox">
+                         <property name="prefix">
+                          <string>Ki: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="6" column="0">
+                        <widget class="QLabel" name="label_103">
+                         <property name="text">
+                          <string>Duty Downramp</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocPllKiBox">
+                         <property name="prefix">
+                          <string>Ki: </string>
+                         </property>
+                         <property name="decimals">
+                          <number>2</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1000000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>1000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="0">
+                        <widget class="QLabel" name="label_90">
+                         <property name="text">
+                          <string>Speed Tracker</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="7" column="1" colspan="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocOpenloopRpmBox">
+                         <property name="keyboardTracking">
+                          <bool>false</bool>
+                         </property>
+                         <property name="prefix">
+                          <string/>
+                         </property>
+                         <property name="suffix">
+                          <string> RPM</string>
+                         </property>
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>10.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="6" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocDutyDownrampKpBox">
+                         <property name="prefix">
+                          <string>Kp: </string>
+                         </property>
+                         <property name="maximum">
+                          <double>10000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="1">
+                        <widget class="QSpinBox" name="mcconfFocFSwBox">
+                         <property name="toolTip">
+                          <string>Switching Frequency</string>
+                         </property>
+                         <property name="suffix">
+                          <string> Hz</string>
+                         </property>
+                         <property name="prefix">
+                          <string>F_SW: </string>
+                         </property>
+                         <property name="maximum">
+                          <number>100000</number>
+                         </property>
+                         <property name="singleStep">
+                          <number>100</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="0">
+                        <widget class="QLabel" name="label_94">
+                         <property name="text">
+                          <string>F_SW and DTc</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocDtCompBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dead time compensation. Getting this value right is important for the low speed performance of the sensorless observer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="prefix">
+                          <string>DTc: </string>
+                         </property>
+                         <property name="suffix">
+                          <string> µS</string>
+                         </property>
+                         <property name="decimals">
+                          <number>3</number>
+                         </property>
+                         <property name="maximum">
+                          <double>10000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QGroupBox" name="groupBox_40">
+                      <property name="title">
+                       <string>Motor Parameters (for Sensorless and Hall Operation)</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_41">
+                       <item row="4" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocObserverGainBox">
+                         <property name="maximum">
+                          <double>100000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>1.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="0">
+                        <widget class="QLabel" name="label_98">
+                         <property name="text">
+                          <string>Observer Gain (x1M)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="4" column="2">
+                        <widget class="QPushButton" name="mcconfFocObserverGainCalcButton">
+                         <property name="text">
+                          <string>Calc (Req: L)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QDoubleSpinBox" name="mcconfFocMotorRBox">
+                         <property name="prefix">
+                          <string>R: </string>
+                         </property>
+                         <property name="suffix">
+                          <string> Ω</string>
+                         </property>
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.001000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocMotorLBox">
+                         <property name="prefix">
+                          <string>L: </string>
+                         </property>
+                         <property name="suffix">
+                          <string> µH</string>
+                         </property>
+                         <property name="decimals">
+                          <number>2</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1000000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocMotorLinkageBox">
+                         <property name="prefix">
+                          <string>λ: </string>
+                         </property>
+                         <property name="decimals">
+                          <number>6</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QGroupBox" name="groupBox_43">
+                      <property name="title">
+                       <string>Sensorless Startup and Low Speed</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_44">
+                       <item row="1" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocDCurrentFactorBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum factor between the D axis and Q axis current.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="prefix">
+                          <string>Factor: </string>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.100000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocSlOpenloopHystBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the filtered RPM has been below openloop RPM for this amount of time, the motor will rotate in open loop with openloop RPM.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="prefix">
+                          <string>Hyst: </string>
+                         </property>
+                         <property name="suffix">
+                          <string> s</string>
+                         </property>
+                         <property name="decimals">
+                          <number>3</number>
+                         </property>
+                         <property name="maximum">
+                          <double>200.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.100000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_105">
+                         <property name="text">
+                          <string>Open Loop</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_107">
+                         <property name="text">
+                          <string>D Current Injection</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfFocDCurrentDutyBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Inject D axis current below this duty cycle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="prefix">
+                          <string>Duty: </string>
+                         </property>
+                         <property name="decimals">
+                          <number>3</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QDoubleSpinBox" name="mcconfFocSlOpenloopTimeBox">
+                         <property name="toolTip">
+                          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Time to remain in open loop before entering closed loop.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         </property>
+                         <property name="prefix">
+                          <string>Time: </string>
+                         </property>
+                         <property name="suffix">
+                          <string> s</string>
+                         </property>
+                         <property name="decimals">
+                          <number>3</number>
+                         </property>
+                         <property name="maximum">
+                          <double>200.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.100000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_46">
+                    <property name="title">
+                     <string>Hall Sensors</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_45">
+                     <item>
+                      <widget class="QLabel" name="label_95">
+                       <property name="text">
+                        <string>Table</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab0Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab1Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab2Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab3Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab4Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab5Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab6Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocHallTab7Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_23">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_17">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Expanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_44">
+                    <property name="title">
+                     <string>Detect and Calculate Parameters</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_45">
+                     <item row="0" column="4">
+                      <spacer name="horizontalSpacer_29">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item row="3" column="1">
+                      <widget class="QDoubleSpinBox" name="mcconfFocCalcCCTcBox">
+                       <property name="prefix">
+                        <string>TC: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> µS</string>
+                       </property>
+                       <property name="decimals">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>10.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>1000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="0">
+                      <widget class="QPushButton" name="mcconfFocMeasureLinkageButton">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spin up the motor using BLDC delay commutation and measure the flux linkage. The motor resistance is required to compensate for load, so it should be measured or entered first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Measure λ (Req: R)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QPushButton" name="mcconfFocMeasureRLButton">
+                       <property name="toolTip">
+                        <string>Measure the motor resistance and inductance.</string>
+                       </property>
+                       <property name="text">
+                        <string>Measure R and L</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectRBox">
+                       <property name="prefix">
+                        <string>R: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> Ω</string>
+                       </property>
+                       <property name="decimals">
+                        <number>5</number>
+                       </property>
+                       <property name="maximum">
+                        <double>1000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.001000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectLBox">
+                       <property name="prefix">
+                        <string>L: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> µH</string>
+                       </property>
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="5">
+                      <widget class="QPushButton" name="mcconfFocApplyRLLambdaButton">
+                       <property name="text">
+                        <string>Apply</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="0">
+                      <widget class="QPushButton" name="mcconfFocCalcCCButton">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Calculate Kp and Ki for the current control loop based on the motor resistance and inductance, and a desired time constant (TC) of the system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Calc CC (Req: R and L)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="5">
+                      <widget class="QPushButton" name="mcconfFocCalcCCApplyButton">
+                       <property name="text">
+                        <string>Apply</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectLinkageBox">
+                       <property name="readOnly">
+                        <bool>true</bool>
+                       </property>
+                       <property name="prefix">
+                        <string>λ: </string>
+                       </property>
+                       <property name="decimals">
+                        <number>8</number>
+                       </property>
+                       <property name="maximum">
+                        <double>100.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.000100000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>0.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="3">
+                      <widget class="QDoubleSpinBox" name="mcconfFocCalcKiBox">
+                       <property name="readOnly">
+                        <bool>true</bool>
+                       </property>
+                       <property name="prefix">
+                        <string>Ki: </string>
+                       </property>
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="2">
+                      <widget class="QDoubleSpinBox" name="mcconfFocCalcKpBox">
+                       <property name="readOnly">
+                        <bool>true</bool>
+                       </property>
+                       <property name="prefix">
+                        <string>Kp: </string>
+                       </property>
+                       <property name="decimals">
+                        <number>4</number>
+                       </property>
+                       <property name="maximum">
+                        <double>1000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.010000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="2" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmBox">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectCurrentBox">
+                       <property name="toolTip">
+                        <string>For measuring flux linkage:  The current to use.</string>
+                       </property>
+                       <property name="prefix">
+                        <string>I: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> A</string>
+                       </property>
+                       <property name="maximum">
+                        <double>150.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>6.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="2">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectDutyBox">
+                       <property name="toolTip">
+                        <string>For measuring flux linkage:  Duty cycle to measure flux linkage at.</string>
+                       </property>
+                       <property name="prefix">
+                        <string>Duty: </string>
+                       </property>
+                       <property name="maximum">
+                        <double>1.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.010000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>0.500000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="3">
+                      <widget class="QDoubleSpinBox" name="mcconfFocDetectMinRpmBox">
+                       <property name="toolTip">
+                        <string>For measuring flux linkage: The minimum RPM to start the motor with.</string>
+                       </property>
+                       <property name="prefix">
+                        <string>RPM: </string>
+                       </property>
+                       <property name="decimals">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <double>10000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>10.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>700.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="4" colspan="2">
+                      <widget class="QLabel" name="label_93">
+                       <property name="text">
+                        <string>← To spin up for λ</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_42">
+                    <property name="title">
+                     <string>Detect Encoder</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_25">
+                     <item>
+                      <widget class="QPushButton" name="mcconfFocMeasureEncoderButton">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run the motor slowly in open loop using the selected current and try to figure out the encoder offset and ratio, and whether the encoder is inverted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Measure</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderCurrentBox">
+                       <property name="prefix">
+                        <string>I: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> A</string>
+                       </property>
+                       <property name="value">
+                        <double>15.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_26">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderOffsetBox">
+                       <property name="readOnly">
+                        <bool>true</bool>
+                       </property>
+                       <property name="prefix">
+                        <string>Ofs: </string>
+                       </property>
+                       <property name="suffix">
+                        <string/>
+                       </property>
+                       <property name="maximum">
+                        <double>360.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderRatioBox">
+                       <property name="readOnly">
+                        <bool>true</bool>
+                       </property>
+                       <property name="prefix">
+                        <string>Rat: </string>
+                       </property>
+                       <property name="suffix">
+                        <string/>
+                       </property>
+                       <property name="maximum">
+                        <double>500.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="mcconfFocMeasureEncoderInvertedBox">
+                       <property name="text">
+                        <string>Invert Encoder</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_27">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="mcconfFocMeasureEncoderApplyButton">
+                       <property name="text">
+                        <string>Apply</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_45">
+                    <property name="title">
+                     <string>Detect Hall Sensors</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_38">
+                     <item>
+                      <widget class="QPushButton" name="mcconfFocMeasureHallButton">
+                       <property name="text">
+                        <string>Measure</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="mcconfFocMeasureHallCurrentBox">
+                       <property name="prefix">
+                        <string>I: </string>
+                       </property>
+                       <property name="suffix">
+                        <string> A</string>
+                       </property>
+                       <property name="value">
+                        <double>15.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_25">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab0Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab1Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab2Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab3Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab4Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab5Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab6Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="mcconfFocMeasureHallTab7Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_24">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="mcconfFocMeasureHallApplyButton">
+                       <property name="text">
+                        <string>Apply</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_14">
+                 <attribute name="title">
+                  <string>Advanced</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_27">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_13">
+                    <property name="title">
+                     <string>PWM mode (DC and BLDC only)</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_44">
+                     <item>
+                      <widget class="QRadioButton" name="mcconfPwmModeSyncButton">
+                       <property name="text">
+                        <string>Synchronous</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="mcconfPwmModeBipolarButton">
+                       <property name="text">
+                        <string>Bipolar</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="mcconfPwmModeNonsyncHiswButton">
+                       <property name="text">
+                        <string>Nonsynchronous-HISW (Not recommended)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_21">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_23">
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_14">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>Current control</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_14">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_34">
+                         <property name="text">
+                          <string>Startup boost (BLDC only)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfCcBoostBox">
+                         <property name="decimals">
+                          <number>3</number>
+                         </property>
+                         <property name="maximum">
+                          <double>1.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_35">
+                         <property name="text">
+                          <string>Min current</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfCcMinBox"/>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_36">
+                         <property name="toolTip">
+                          <string>Only change this if you know what you are doing</string>
+                         </property>
+                         <property name="text">
+                          <string>Gain (BLDC and DC only)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfCcGainBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="maximum">
+                          <double>50.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <spacer name="verticalSpacer_16">
+                         <property name="orientation">
+                          <enum>Qt::Vertical</enum>
+                         </property>
+                         <property name="sizeType">
+                          <enum>QSizePolicy::Preferred</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>20</width>
+                           <height>25</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_37">
+                      <property name="title">
+                       <string>Backoff and ramping (DC and BLDC only)</string>
+                      </property>
+                      <property name="flat">
+                       <bool>false</bool>
+                      </property>
+                      <property name="checkable">
+                       <bool>false</bool>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_37">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_3">
+                         <property name="text">
+                          <string>Duty ramp step (at 1 kHz)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfMDutyRampStepBox">
+                         <property name="decimals">
+                          <number>4</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_69">
+                         <property name="text">
+                          <string>Max current ramp step (at 1 kHz)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfCcMaxRampStepBox">
+                         <property name="decimals">
+                          <number>4</number>
+                         </property>
+                         <property name="maximum">
+                          <double>50.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_85">
+                         <property name="text">
+                          <string>Current backoff gain</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfMCurrentBackoffGainBox">
+                         <property name="decimals">
+                          <number>4</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.010000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_33">
+                         <property name="text">
+                          <string>Speed limit ramp step</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfMDutyRampStepSpeedLimBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_39">
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_15">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>Speed control</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_15">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_37">
+                         <property name="text">
+                          <string>KP</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSpidKpBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_38">
+                         <property name="text">
+                          <string>KI</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSpidKiBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_39">
+                         <property name="text">
+                          <string>KD</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSpidKdBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_40">
+                         <property name="text">
+                          <string>MIN ERPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfSpidMinRpmBox">
+                         <property name="maximum">
+                          <double>200000.000000000000000</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>100.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_30">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="title">
+                       <string>Position control</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_26">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_68">
+                         <property name="text">
+                          <string>KP</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfPpidKiBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QLabel" name="label_70">
+                         <property name="text">
+                          <string>KI</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfPpidKdBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QLabel" name="label_71">
+                         <property name="text">
+                          <string>KD</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfPpidKpBox">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.000100000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="0">
+                        <widget class="QLabel" name="label_11">
+                         <property name="text">
+                          <string>Angle division</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="3" column="1">
+                        <widget class="QDoubleSpinBox" name="mcconfPpidAngDivBox">
+                         <property name="minimum">
+                          <double>0.010000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>10000.000000000000000</double>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_53">
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_17">
+                      <property name="title">
+                       <string>Misc</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_38">
+                       <item row="0" column="1">
+                        <widget class="QLabel" name="label_4">
+                         <property name="text">
+                          <string>Fault stop time</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QSpinBox" name="mcconfMEncoderCountBox">
+                         <property name="maximum">
+                          <number>1000000</number>
+                         </property>
+                         <property name="singleStep">
+                          <number>100</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QSpinBox" name="mcconfMFaultStopTimeBox">
+                         <property name="suffix">
+                          <string> ms</string>
+                         </property>
+                         <property name="minimum">
+                          <number>-1</number>
+                         </property>
+                         <property name="maximum">
+                          <number>40000000</number>
+                         </property>
+                         <property name="singleStep">
+                          <number>500</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QLabel" name="label_91">
+                         <property name="text">
+                          <string>Encoder Counts</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_3">
+                      <property name="title">
+                       <string>Hall/encoder port mode</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_43">
+                       <item row="0" column="0">
+                        <widget class="QRadioButton" name="mcconfMSensorHallButton">
+                         <property name="text">
+                          <string>Hall sensors</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QRadioButton" name="mcconfMSensorAsSpiButton">
+                         <property name="text">
+                          <string>AS5047/AS5048 SPI</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QRadioButton" name="mcconfMSensorAbiButton">
+                         <property name="text">
+                          <string>ABI encoder</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_22">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_8">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_4">
+                 <attribute name="title">
+                  <string>Description</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_25">
+                  <item>
+                   <widget class="MRichTextEdit" name="mcconfDescEdit" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_17">
+                <item>
+                 <widget class="QPushButton" name="mcconfReadButton">
+                  <property name="text">
+                   <string>Read configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="mcconfReadDefaultButton">
+                  <property name="text">
+                   <string>Read default configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="mcconfWriteButton">
+                  <property name="text">
+                   <string>Write configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_6">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="mcconfLoadXmlButton">
+                  <property name="text">
+                   <string>Load XML</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="mcconfSaveXmlButton">
+                  <property name="text">
+                   <string>Save XML</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_5">
+             <attribute name="title">
+              <string>App Configuration</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_33">
+              <item>
+               <widget class="QTabWidget" name="tabWidget_3">
+                <property name="tabPosition">
+                 <enum>QTabWidget::West</enum>
+                </property>
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <widget class="QWidget" name="tab_16">
+                 <attribute name="title">
+                  <string>General</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_3">
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_5">
+                    <item>
+                     <widget class="QGroupBox" name="groupBox_28">
+                      <property name="title">
+                       <string>Settings</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_29">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_65">
+                         <property name="text">
+                          <string>Controller ID</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QSpinBox" name="appconfControllerIdBox">
+                         <property name="maximum">
+                          <number>255</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QGroupBox" name="appconfSendCanStatusBox">
+                      <property name="title">
+                       <string>Send status over CAN</string>
+                      </property>
+                      <property name="checkable">
+                       <bool>true</bool>
+                      </property>
+                      <property name="checked">
+                       <bool>false</bool>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_25">
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="label_12">
+                         <property name="text">
+                          <string>Rate (Hz)</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QSpinBox" name="appconfSendCanStatusRateBox">
+                         <property name="maximum">
+                          <number>1000</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_18">
+                    <property name="title">
+                     <string>App to use (Changing this requires a reboot)</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_33">
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_22">
+                       <item row="1" column="0">
+                        <widget class="QRadioButton" name="appconfUseUartButton">
+                         <property name="text">
+                          <string>UART</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QRadioButton" name="appconfUsePpmUartButton">
+                         <property name="text">
+                          <string>PPM and UART</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="2">
+                        <widget class="QRadioButton" name="appconfUseCustomButton">
+                         <property name="text">
+                          <string>Custom user application</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QRadioButton" name="appconfUseNoAppButton">
+                         <property name="text">
+                          <string>No app</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QRadioButton" name="appconfUseNrfButton">
+                         <property name="text">
+                          <string>NRF</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QRadioButton" name="appconfUseNunchukButton">
+                         <property name="text">
+                          <string>Nunchuk</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QRadioButton" name="appconfUsePpmButton">
+                         <property name="text">
+                          <string>PPM</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QRadioButton" name="appconfUseAdcButton">
+                         <property name="text">
+                          <string>ADC</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QRadioButton" name="appconfUseAdcUartButton">
+                         <property name="text">
+                          <string>ADC and UART</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_12">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>561</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_22">
+                    <property name="title">
+                     <string>Timeout (when no control signal is received)</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_18">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_52">
+                       <property name="text">
+                        <string>Timeout (ms)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="appconfTimeoutBox">
+                       <property name="maximum">
+                        <number>30000</number>
+                       </property>
+                       <property name="singleStep">
+                        <number>500</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_53">
+                       <property name="text">
+                        <string>Brake current to use when a timeout occurs (A)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfTimeoutBrakeCurrentBox">
+                       <property name="maximum">
+                        <double>200.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_3">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>396</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_17">
+                 <attribute name="title">
+                  <string>PPM</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_35">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_19">
+                    <property name="title">
+                     <string>Control mode</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_28">
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_13">
+                       <item row="0" column="2">
+                        <widget class="QRadioButton" name="appconfPpmDutyNorevButton">
+                         <property name="text">
+                          <string>Duty cycle no reverse</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QRadioButton" name="appconfPpmDutyButton">
+                         <property name="text">
+                          <string>Duty cycle</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QRadioButton" name="appconfPpmDisabledButton">
+                         <property name="text">
+                          <string>Disabled</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="3">
+                        <widget class="QRadioButton" name="appconfPpmPidNorevButton">
+                         <property name="text">
+                          <string>PID speed control no reverse</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QRadioButton" name="appconfPpmCurrentNorevBrakeButton">
+                         <property name="text">
+                          <string>Current no reverse with brake</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="3">
+                        <widget class="QRadioButton" name="appconfPpmCurrentButton">
+                         <property name="text">
+                          <string>Current</string>
+                         </property>
+                         <property name="checked">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QRadioButton" name="appconfPpmCurrentNorevButton">
+                         <property name="text">
+                          <string>Current no reverse</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QRadioButton" name="appconfPpmPidButton">
+                         <property name="text">
+                          <string>PID speed control</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_10">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>411</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_20">
+                    <property name="title">
+                     <string>Settings</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_17">
+                     <item row="4" column="0">
+                      <widget class="QCheckBox" name="appconfPpmMedianFilterBox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a median filter to reject niose. This will introduce one sample delay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Use Median Filter</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="0">
+                      <widget class="QLabel" name="label_51">
+                       <property name="text">
+                        <string>Maximum Pulsewidth (ms)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmPidMaxErpmBox">
                        <property name="maximum">
                         <double>200000.000000000000000</double>
                        </property>
@@ -251,52 +3089,495 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmFbrakeBox">
-                       <property name="maximum">
-                        <double>100000.000000000000000</double>
-                       </property>
-                       <property name="singleStep">
-                        <double>100.000000000000000</double>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_49">
+                       <property name="text">
+                        <string>Deadband</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMinErpmBox">
-                       <property name="minimum">
-                        <double>-200000.000000000000000</double>
-                       </property>
+                     <item row="2" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmPulseStartBox">
                        <property name="maximum">
-                        <double>0.000000000000000</double>
+                        <double>10.000000000000000</double>
                        </property>
                        <property name="singleStep">
-                        <double>100.000000000000000</double>
+                        <double>0.100000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="2" column="0">
-                      <widget class="QLabel" name="label_22">
+                      <widget class="QLabel" name="label_50">
                        <property name="text">
-                        <string>Max ERPM</string>
+                        <string>Minimum Pulsewidth (ms)</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="label_23">
-                       <property name="text">
-                        <string>Max ERPM at full brake</string>
+                     <item row="3" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmPulseWidthBox">
+                       <property name="maximum">
+                        <double>20.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.100000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="0" column="0">
-                      <widget class="QCheckBox" name="mcconfLimErpmLimitNegTorqueBox">
+                      <widget class="QLabel" name="label_45">
                        <property name="text">
-                        <string>Limit ERPM with negative torque</string>
+                        <string>PID max ERPM</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmHystBox">
+                       <property name="maximum">
+                        <double>1.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.050000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="5" column="0">
-                      <spacer name="verticalSpacer_11">
+                      <widget class="QCheckBox" name="appconfPpmSafeStartBox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Don't give throttle unless the received output has been 0 for at leas 50 pulses. The counter is reset on boot, every time a new configuration is loaded and when a timeout occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Safe Start</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfPpmRpmLimBox">
+                    <property name="title">
+                     <string>Soft RPM limit (current mode only)</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_20">
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmRpmLimStartBox">
+                       <property name="maximum">
+                        <double>200000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_47">
+                       <property name="text">
+                        <string>ERPM limit start</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_48">
+                       <property name="text">
+                        <string>ERPM limit end</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfPpmRpmLimEndBox">
+                       <property name="maximum">
+                        <double>200000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfPpmMultiGroup">
+                    <property name="title">
+                     <string>Multiple ESCs over CAN</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_37">
+                     <item>
+                      <widget class="QCheckBox" name="appconfPpmTcBox">
+                       <property name="text">
+                        <string>Enable Traction Control (current mode only)</string>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_14">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_67">
+                       <property name="text">
+                        <string>Traction Control ERPM diff</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="appconfPpmTcErpmBox">
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>3000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfUpdatePpmBox">
+                    <property name="title">
+                     <string>Display</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_19">
+                     <item row="0" column="0">
+                      <widget class="QProgressBar" name="appconfDecodedPpmBar">
+                       <property name="minimum">
+                        <number>0</number>
+                       </property>
+                       <property name="maximum">
+                        <number>1000</number>
+                       </property>
+                       <property name="value">
+                        <number>0</number>
+                       </property>
+                       <property name="format">
+                        <string>%p%</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QLCDNumber" name="appconfPpmPulsewidthNumber"/>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QLabel" name="label_80">
+                       <property name="text">
+                        <string>Pulsewidth (ms):</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_6">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>221</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_22">
+                 <attribute name="title">
+                  <string>ADC</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_16">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_31">
+                    <property name="title">
+                     <string>Control mode</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_40">
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_30">
+                       <item row="0" column="3">
+                        <widget class="QRadioButton" name="appconfAdcCurrentButtonButton">
+                         <property name="text">
+                          <string>Current button</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QRadioButton" name="appconfAdcDisabledButton">
+                         <property name="text">
+                          <string>Disabled</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="4">
+                        <widget class="QRadioButton" name="appconfAdcCurrentNorevCenterButton">
+                         <property name="text">
+                          <string>Current norev center</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="0">
+                        <widget class="QRadioButton" name="appconfAdcCurrentNorevButtonButton">
+                         <property name="text">
+                          <string>Current norev button</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QRadioButton" name="appconfAdcCurrentButton">
+                         <property name="text">
+                          <string>Current</string>
+                         </property>
+                         <property name="checked">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QRadioButton" name="appconfAdcCurrentCenterButton">
+                         <property name="text">
+                          <string>Current center</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="4">
+                        <widget class="QRadioButton" name="appconfAdcDutyCycleButtonButton">
+                         <property name="text">
+                          <string>Duty cycle button</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="3">
+                        <widget class="QRadioButton" name="appconfAdcDutyCycleCenterButton">
+                         <property name="text">
+                          <string>Duty cycle center</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QRadioButton" name="appconfAdcDutyCycleButton">
+                         <property name="text">
+                          <string>Duty cycle</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QRadioButton" name="appconfAdcCurrentNorevAdcButton">
+                         <property name="text">
+                          <string>Current norev ADC2</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_16">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>411</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_33">
+                    <property name="title">
+                     <string>Settings</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_33">
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="appconfAdcUpdateRateBox">
+                       <property name="suffix">
+                        <string> Hz</string>
+                       </property>
+                       <property name="maximum">
+                        <number>10000</number>
+                       </property>
+                       <property name="singleStep">
+                        <number>10</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfAdcHystBox">
+                       <property name="maximum">
+                        <double>1.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.050000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_78">
+                       <property name="text">
+                        <string>Update Rate</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="5">
+                      <widget class="QCheckBox" name="appconfAdcFilterBox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a median filter to reject niose. This will introduce one sample delay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Use Filter</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_76">
+                       <property name="text">
+                        <string>Deadband</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="5">
+                      <widget class="QCheckBox" name="appconfAdcSafeStartBox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Don't give throttle unless the received output has been 0 for at leas 50 pulses. The counter is reset on boot, every time a new configuration is loaded and when a timeout occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="text">
+                        <string>Safe Start</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QWidget" name="widget" native="true">
+                       <property name="minimumSize">
+                        <size>
+                         <width>50</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="7">
+                      <spacer name="horizontalSpacer_18">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item row="0" column="4">
+                      <widget class="QDoubleSpinBox" name="appconfAdcVoltageStartBox">
+                       <property name="suffix">
+                        <string> V</string>
+                       </property>
+                       <property name="maximum">
+                        <double>10.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.010000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QLabel" name="label_77">
+                       <property name="text">
+                        <string>Minimum Voltage</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="3">
+                      <widget class="QLabel" name="label_75">
+                       <property name="text">
+                        <string>Maximum Voltage</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="4">
+                      <widget class="QDoubleSpinBox" name="appconfAdcVoltageEndBox">
+                       <property name="suffix">
+                        <string> V</string>
+                       </property>
+                       <property name="maximum">
+                        <double>20.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.010000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="6">
+                      <widget class="QCheckBox" name="appconfAdcInvertVoltageBox">
+                       <property name="text">
+                        <string>Invert Voltage</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_36">
+                    <property name="title">
+                     <string>Buttons</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_35">
+                     <item row="2" column="0">
+                      <widget class="QCheckBox" name="appconfAdcInvertRevButtonBox">
+                       <property name="text">
+                        <string>Invert reverse button</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="0">
+                      <widget class="QCheckBox" name="appconfAdcInvertCcButtonBox">
+                       <property name="text">
+                        <string>Invert cruise control button</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="4" column="0">
+                      <spacer name="verticalSpacer_12">
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
                        </property>
@@ -308,202 +3589,1580 @@
                        </property>
                       </spacer>
                      </item>
-                     <item row="4" column="0">
-                      <widget class="QLabel" name="label_62">
-                       <property name="text">
-                        <string>Max ERPM at full brake in current control mode</string>
+                     <item row="2" column="1" rowspan="3">
+                      <widget class="QTextBrowser" name="textBrowser_2">
+                       <property name="html">
+                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;The cruise control button will maintain the current speed while pressed when current control is used and no throttle is given. The reverse button is used to reverse the throttle when one of the corresponding control modes is used.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;When only the ADC app is used, the TX pin is used for the cruise control button and the RX pin is used for the reverse button. When the ADC and UART apps are used at the same time, the servo input will be used as the button. In this case it will be used for the reverse button when a control mode with button is selected, otherwise it will be used for the cruise control button.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="4" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMaxErpmFbrakeCcBox">
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfAdcRpmLimBox">
+                    <property name="title">
+                     <string>Soft RPM limit (current mode only)</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_32">
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfAdcRpmLimStartBox">
                        <property name="maximum">
-                        <double>100000.000000000000000</double>
+                        <double>200000.000000000000000</double>
                        </property>
                        <property name="singleStep">
                         <double>100.000000000000000</double>
                        </property>
                       </widget>
                      </item>
-                    </layout>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QGroupBox" name="groupBox_27">
-                  <property name="title">
-                   <string>Temperature Limits</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_23">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_57">
-                     <property name="text">
-                      <string>MOSFET Start</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfLimTempFetStartBox">
-                     <property name="suffix">
-                      <string> °C</string>
-                     </property>
-                     <property name="minimum">
-                      <double>-100.000000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>300.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>5.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_58">
-                     <property name="text">
-                      <string>MOSFET End</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfLimTempFetEndBox">
-                     <property name="suffix">
-                      <string> °C</string>
-                     </property>
-                     <property name="minimum">
-                      <double>-100.000000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>300.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>5.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_59">
-                     <property name="text">
-                      <string>Motor Start</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfLimTempMotorStartBox">
-                     <property name="suffix">
-                      <string> °C</string>
-                     </property>
-                     <property name="minimum">
-                      <double>-100.000000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>300.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>5.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_60">
-                     <property name="text">
-                      <string>Motor End</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfLimTempMotorEndBox">
-                     <property name="suffix">
-                      <string> °C</string>
-                     </property>
-                     <property name="minimum">
-                      <double>-100.000000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>300.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>5.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QGroupBox" name="groupBox_10">
-                  <property name="title">
-                   <string>Voltage Limits</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_20">
-                   <item>
-                    <layout class="QGridLayout" name="gridLayout_11">
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="label_86">
-                       <property name="text">
-                        <string>Battery cutoff start</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_25">
-                       <property name="text">
-                        <string>Maximum input voltage</string>
-                       </property>
-                      </widget>
-                     </item>
                      <item row="0" column="0">
-                      <widget class="QLabel" name="label_24">
+                      <widget class="QLabel" name="label_73">
                        <property name="text">
-                        <string>Minimum input voltage</string>
+                        <string>ERPM limit start</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="4">
+                      <widget class="QDoubleSpinBox" name="appconfAdcRpmLimEndBox">
+                       <property name="maximum">
+                        <double>200000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QLabel" name="label_74">
+                       <property name="text">
+                        <string>ERPM limit end</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <spacer name="horizontalSpacer_28">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfAdcMultiGroup">
+                    <property name="title">
+                     <string>Multiple ESCs over CAN</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_41">
+                     <item>
+                      <widget class="QCheckBox" name="appconfAdcTcBox">
+                       <property name="text">
+                        <string>Enable Traction Control (current mode only)</string>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_17">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_72">
+                       <property name="text">
+                        <string>Traction Control ERPM diff</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="appconfAdcTcErpmBox">
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>3000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfAdcUpdateBox">
+                    <property name="title">
+                     <string>Display</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_31">
+                     <item row="0" column="0">
+                      <widget class="QProgressBar" name="appconfAdcDecodedBar">
+                       <property name="minimum">
+                        <number>0</number>
+                       </property>
+                       <property name="maximum">
+                        <number>1000</number>
+                       </property>
+                       <property name="value">
+                        <number>0</number>
+                       </property>
+                       <property name="format">
+                        <string>%p%</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QLCDNumber" name="appconfAdcVoltageNumber">
+                       <property name="value" stdset="0">
+                        <double>0.000000000000000</double>
                        </property>
                       </widget>
                      </item>
                      <item row="0" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMinVinBox">
-                       <property name="suffix">
-                        <string> V</string>
+                      <widget class="QLabel" name="label_79">
+                       <property name="text">
+                        <string>ADC (V):</string>
                        </property>
-                       <property name="minimum">
-                        <double>6.000000000000000</double>
-                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QProgressBar" name="appconfAdcDecodedBar2">
                        <property name="maximum">
-                        <double>60.000000000000000</double>
+                        <number>1000</number>
+                       </property>
+                       <property name="value">
+                        <number>0</number>
                        </property>
                       </widget>
                      </item>
                      <item row="1" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimMaxVinBox">
-                       <property name="suffix">
-                        <string> V</string>
-                       </property>
-                       <property name="minimum">
-                        <double>6.000000000000000</double>
-                       </property>
-                       <property name="maximum">
-                        <double>60.000000000000000</double>
+                      <widget class="QLabel" name="lblVoltage2">
+                       <property name="text">
+                        <string>ADC2 (V):</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="label_87">
+                     <item row="1" column="2">
+                      <widget class="QLCDNumber" name="appconfAdcVoltageNumber2"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_14">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>76</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_18">
+                 <attribute name="title">
+                  <string>UART</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_36">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_21">
+                    <property name="title">
+                     <string>Settings</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_16">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_46">
                        <property name="text">
-                        <string>Battery cutoff end</string>
+                        <string>Baud rate</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="appconfUartBaudBox">
+                       <property name="maximum">
+                        <number>20000000</number>
+                       </property>
+                       <property name="singleStep">
+                        <number>2400</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_10">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>470</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_21">
+                 <attribute name="title">
+                  <string>Nunchuk</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_32">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_24">
+                    <property name="title">
+                     <string>Control mode</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_31">
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_35">
+                       <item>
+                        <widget class="QRadioButton" name="appconfChukDisabledButton">
+                         <property name="text">
+                          <string>Disabled</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QRadioButton" name="appconfChukCurrentNorevButton">
+                         <property name="text">
+                          <string>Current</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QRadioButton" name="appconfChukCurrentButton">
+                         <property name="text">
+                          <string>Current with reverse</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_11">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>720</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_25">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="title">
+                     <string>Settings</string>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_21">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_54">
+                       <property name="text">
+                        <string>Deadband</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfChukHystBox">
+                       <property name="maximum">
+                        <double>1.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.050000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QLabel" name="label_63">
+                       <property name="text">
+                        <string>Positive ramping time constant</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QDoubleSpinBox" name="appconfChukRampTimePosBox">
+                       <property name="singleStep">
+                        <double>0.100000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>1.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_56">
+                       <property name="text">
+                        <string>ERPM limit start</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QDoubleSpinBox" name="appconfChukRpmLimStartBox">
+                       <property name="maximum">
+                        <double>200000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QLabel" name="label_64">
+                       <property name="text">
+                        <string>Negative ramping time constant</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="3">
+                      <widget class="QDoubleSpinBox" name="appconfChukRampTimeNegBox">
+                       <property name="singleStep">
+                        <double>0.100000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>0.500000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="0">
+                      <widget class="QLabel" name="label_55">
+                       <property name="text">
+                        <string>ERPM limit end</string>
                        </property>
                       </widget>
                      </item>
                      <item row="2" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimBatteryCutStartBox">
-                       <property name="suffix">
-                        <string> V</string>
+                      <widget class="QDoubleSpinBox" name="appconfChukRpmLimEndBox">
+                       <property name="maximum">
+                        <double>200000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="1">
-                      <widget class="QDoubleSpinBox" name="mcconfLimBatteryCutEndBox">
-                       <property name="suffix">
-                        <string> V</string>
+                     <item row="2" column="2">
+                      <widget class="QLabel" name="label_88">
+                       <property name="text">
+                        <string>ERPM/S input in cruise control</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="3">
+                      <widget class="QDoubleSpinBox" name="appconfChukErpmPerSBox">
+                       <property name="decimals">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>100.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>3000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                    <zorder>label_56</zorder>
+                    <zorder>appconfChukRpmLimStartBox</zorder>
+                    <zorder>label_54</zorder>
+                    <zorder>appconfChukHystBox</zorder>
+                    <zorder>label_55</zorder>
+                    <zorder>appconfChukRpmLimEndBox</zorder>
+                    <zorder>label_63</zorder>
+                    <zorder>appconfChukRampTimePosBox</zorder>
+                    <zorder>label_64</zorder>
+                    <zorder>appconfChukRampTimeNegBox</zorder>
+                    <zorder>label_88</zorder>
+                    <zorder>appconfChukErpmPerSBox</zorder>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfChukMultiGroup">
+                    <property name="title">
+                     <string>Multiple ESCs over CAN</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_36">
+                     <item>
+                      <widget class="QCheckBox" name="appconfChukTcBox">
+                       <property name="text">
+                        <string>Enable Traction Control</string>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_13">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_66">
+                       <property name="text">
+                        <string>Traction Control ERPM diff</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QDoubleSpinBox" name="appconfChukTcErpmBox">
+                       <property name="maximum">
+                        <double>100000.000000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>3000.000000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="appconfUpdateChukBox">
+                    <property name="title">
+                     <string>Display</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_32">
+                     <item>
+                      <widget class="QProgressBar" name="appconfDecodedChukBar">
+                       <property name="minimum">
+                        <number>0</number>
+                       </property>
+                       <property name="maximum">
+                        <number>1000</number>
+                       </property>
+                       <property name="value">
+                        <number>0</number>
+                       </property>
+                       <property name="format">
+                        <string>%p%</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QTextBrowser" name="textBrowser">
+                    <property name="html">
+                     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;This has been tested with the wireless Nyko Kama nunchuk. The receiver can be connected directly to the I2C port on the ESC. The y-axis on the joystick is used for acceleration/braking. The buttons have the following functions:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-weight:600;&quot;&gt;C-Button:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;Cruise control. If the C-button is pressed, the ESC will maintail the current speed with a PID control loop. The joystick can still be used to accelerate and brake, but as soon as it is returned to the center position the new speed will be maintained, as long as the C-button remains pressed.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-weight:600;&quot;&gt;Z-Button:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;The Z-button is used to change the direction of the motor if reverse is activated. Without reverse, Z has no effect.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Ubuntu';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;There is also a safety function. If nothing received from the nunchuk (including the accelerometers) changes for longer than the timeout value in the &lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-style:italic;&quot;&gt;General&lt;/span&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt; tab, the timeout function will be activated and either release the motor or brake with the current specified next to the timeout value.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_25">
+                 <attribute name="title">
+                  <string>NRF</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_37">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_47">
+                    <property name="title">
+                     <string>Speed</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_46">
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfSpeed250kButton">
+                       <property name="text">
+                        <string>250K</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfSpeed1mButton">
+                       <property name="text">
+                        <string>1M</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfSpeed2mButton">
+                       <property name="text">
+                        <string>2M</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_33">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_48">
+                    <property name="title">
+                     <string>Power</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_47">
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfPowerM18Button">
+                       <property name="text">
+                        <string>-18 dBm</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfPowerM12Button">
+                       <property name="text">
+                        <string>-12 dBm</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfPowerM6Button">
+                       <property name="text">
+                        <string>-6 dBm</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfPower0Button">
+                       <property name="text">
+                        <string>0 dBm</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_31">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_50">
+                    <property name="title">
+                     <string>CRC</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_49">
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfCrc1BButton">
+                       <property name="text">
+                        <string>1 Byte</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="appconfNrfCrc2BButton">
+                       <property name="text">
+                        <string>2 Byte</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_32">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_49">
+                    <property name="title">
+                     <string>Ack Retry</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_48">
+                     <item>
+                      <widget class="QCheckBox" name="appconfNrfUseAckBox">
+                       <property name="text">
+                        <string>Use Ack</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_97">
+                       <property name="text">
+                        <string>Retries</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="appconfNrfRetrBox">
+                       <property name="maximum">
+                        <number>15</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_99">
+                       <property name="text">
+                        <string>Delay</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QComboBox" name="appconfNrfRetrDelayBox">
+                       <property name="currentIndex">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <property name="text">
+                         <string>250 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>500 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>750 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>1000 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>1250 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>1500 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>1750 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>2000 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>2250 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>2500 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>2750 µs</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>3000 µS</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>3250 µS</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>3500 µS</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>3750 µS</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
+                         <string>4000 µS</string>
+                        </property>
+                       </item>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_30">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_51">
+                    <property name="title">
+                     <string>Channel</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_50">
+                     <item>
+                      <widget class="QSpinBox" name="appconfNrfChannelBox">
+                       <property name="maximum">
+                        <number>125</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_34">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>836</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_52">
+                    <property name="title">
+                     <string>Address</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_51">
+                     <item>
+                      <widget class="QSpinBox" name="appconfNrfAddrB0Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="appconfNrfAddrB1Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="appconfNrfAddrB2Box">
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_35">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>710</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_18">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>213</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_27">
+                <item>
+                 <widget class="QPushButton" name="appconfReadButton">
+                  <property name="text">
+                   <string>Read configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="appconfReadDefaultButton">
+                  <property name="text">
+                   <string>Read default configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="appconfWriteButton">
+                  <property name="text">
+                   <string>Write configuration</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_6">
+             <attribute name="title">
+              <string>Realtime Data</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_17">
+              <item>
+               <widget class="QTabWidget" name="tabWidget_5">
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <widget class="QWidget" name="tab_19">
+                 <attribute name="title">
+                  <string>Current/Duty</string>
+                 </attribute>
+                 <layout class="QHBoxLayout" name="horizontalLayout_29">
+                  <item>
+                   <widget class="QCustomPlot" name="realtimePlotRest" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_20">
+                 <attribute name="title">
+                  <string>Temperatures</string>
+                 </attribute>
+                 <layout class="QHBoxLayout" name="horizontalLayout_30">
+                  <item>
+                   <widget class="QCustomPlot" name="realtimePlotTemperature" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_28">
+                 <attribute name="title">
+                  <string>RPM</string>
+                 </attribute>
+                 <layout class="QHBoxLayout" name="horizontalLayout_52">
+                  <item>
+                   <widget class="QCustomPlot" name="realtimePlotRpm" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <widget class="RtDataWidget" name="rtDataWidget" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>140</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_16">
+                <item>
+                 <widget class="QCheckBox" name="realtimeAutoScaleBox">
+                  <property name="text">
+                   <string>Auto Scale</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="realtimeActivateBox">
+                  <property name="text">
+                   <string>Activate sampling</string>
+                  </property>
+                  <property name="tristate">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_7">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_2">
+             <attribute name="title">
+              <string>BEMF Plot</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_10">
+              <item>
+               <widget class="QCustomPlot" name="voltagePlot" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QCheckBox" name="showPh1Box">
+                  <property name="text">
+                   <string>Phase 1</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showPh2Box">
+                  <property name="text">
+                   <string>Phase 2</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showPh3Box">
+                  <property name="text">
+                   <string>Phase 3</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showVirtualGndBox">
+                  <property name="text">
+                   <string>Virtual Ground</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showPosVoltageBox">
+                  <property name="text">
+                   <string>Position</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_2">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="truncateBox">
+                  <property name="text">
+                   <string>Truncate non-conducting phases</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab">
+             <attribute name="title">
+              <string>Current Plot</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_19">
+              <item>
+               <widget class="QTabWidget" name="tabWidget_2">
+                <property name="tabPosition">
+                 <enum>QTabWidget::West</enum>
+                </property>
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
+                <widget class="QWidget" name="tab_7">
+                 <attribute name="title">
+                  <string>Plot</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_8">
+                  <item>
+                   <widget class="QCustomPlot" name="currentPlot" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_14">
+                    <item>
+                     <widget class="QCheckBox" name="showCurrent1Box">
+                      <property name="text">
+                       <string>Current 1</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="showCurrent2Box">
+                      <property name="text">
+                       <string>Current 2</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="showCurrent3Box">
+                      <property name="text">
+                       <string>Current 3</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="showTotalCurrentBox">
+                      <property name="text">
+                       <string>Total current</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="showMcTotalCurrentBox">
+                      <property name="text">
+                       <string>MC total current</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="showPosCurrentBox">
+                      <property name="text">
+                       <string>Position</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_3">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="currentTimeButton">
+                      <property name="text">
+                       <string>Time</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="currentSpectrumButton">
+                      <property name="text">
+                       <string>Spectrum</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_8">
+                 <attribute name="title">
+                  <string>Filter 1</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_12">
+                  <item>
+                   <widget class="QSplitter" name="splitter">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <widget class="QWidget" name="layoutWidget">
+                     <layout class="QVBoxLayout" name="verticalLayout_7">
+                      <item>
+                       <widget class="QCustomPlot" name="filterResponsePlot" native="true"/>
+                      </item>
+                      <item>
+                       <widget class="QCheckBox" name="filterLogScaleBox">
+                        <property name="text">
+                         <string>Logscale</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="layoutWidget_12">
+                     <layout class="QVBoxLayout" name="verticalLayout_9">
+                      <item>
+                       <widget class="QCustomPlot" name="filterPlot" native="true"/>
+                      </item>
+                      <item>
+                       <widget class="QCheckBox" name="filterScatterBox">
+                        <property name="text">
+                         <string>Scatterplot</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QWidget" name="tab_9">
+                 <attribute name="title">
+                  <string>Filter 2</string>
+                 </attribute>
+                 <layout class="QVBoxLayout" name="verticalLayout_15">
+                  <item>
+                   <widget class="QSplitter" name="splitter_2">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <widget class="QWidget" name="layoutWidget_10">
+                     <layout class="QVBoxLayout" name="verticalLayout_13">
+                      <item>
+                       <widget class="QCustomPlot" name="filterResponsePlot2" native="true"/>
+                      </item>
+                      <item>
+                       <widget class="QCheckBox" name="filterLogScaleBox2">
+                        <property name="text">
+                         <string>Logscale</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="layoutWidget2_2">
+                     <layout class="QVBoxLayout" name="verticalLayout_14">
+                      <item>
+                       <widget class="QCustomPlot" name="filterPlot2" native="true"/>
+                      </item>
+                      <item>
+                       <widget class="QCheckBox" name="filterScatterBox2">
+                        <property name="text">
+                         <string>Scatterplot</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <item>
+                 <widget class="QGroupBox" name="groupBox_4">
+                  <property name="title">
+                   <string>Filter 1</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_4">
+                   <item row="0" column="0">
+                    <widget class="QCheckBox" name="currentFilterActiveBox">
+                     <property name="text">
+                      <string>Activate</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_6">
+                     <item>
+                      <widget class="QRadioButton" name="firRadioButton">
+                       <property name="text">
+                        <string>FIR</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="meanRadioButton">
+                       <property name="text">
+                        <string>Mean value</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QCheckBox" name="compDelayBox">
+                     <property name="text">
+                      <string>Delay Comp</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1" rowspan="2">
+                    <layout class="QGridLayout" name="gridLayout_3">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_6">
+                       <property name="text">
+                        <string>Stop Frequency</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="currentFilterFreqBox">
+                       <property name="decimals">
+                        <number>3</number>
+                       </property>
+                       <property name="maximum">
+                        <double>0.500000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.005000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>0.050000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_7">
+                       <property name="text">
+                        <string>Filter Taps (2^)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QSpinBox" name="currentFilterTapBox">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <number>10</number>
+                       </property>
+                       <property name="value">
+                        <number>6</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QCheckBox" name="hammingBox">
+                     <property name="text">
+                      <string>Hammnig</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_7">
+                  <property name="title">
+                   <string>Filter 2</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_5">
+                   <item row="0" column="0">
+                    <widget class="QCheckBox" name="currentFilterActiveBox2">
+                     <property name="text">
+                      <string>Activate</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_11">
+                     <item>
+                      <widget class="QRadioButton" name="firRadioButton2">
+                       <property name="text">
+                        <string>FIR</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="meanRadioButton2">
+                       <property name="text">
+                        <string>Mean value</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item row="1" column="1" rowspan="2">
+                    <layout class="QGridLayout" name="gridLayout_6">
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_8">
+                       <property name="text">
+                        <string>Stop Frequency</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QDoubleSpinBox" name="currentFilterFreqBox2">
+                       <property name="decimals">
+                        <number>3</number>
+                       </property>
+                       <property name="maximum">
+                        <double>0.500000000000000</double>
+                       </property>
+                       <property name="singleStep">
+                        <double>0.005000000000000</double>
+                       </property>
+                       <property name="value">
+                        <double>0.050000000000000</double>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_9">
+                       <property name="text">
+                        <string>Filter Taps (2^)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QSpinBox" name="currentFilterTapBox2">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <number>10</number>
+                       </property>
+                       <property name="value">
+                        <number>6</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QCheckBox" name="hammingBox2">
+                     <property name="text">
+                      <string>Hamming</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <layout class="QHBoxLayout" name="horizontalLayout_12">
+                     <item>
+                      <widget class="QLabel" name="label_10">
+                       <property name="text">
+                        <string>Decimation</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="decimationSpinBox">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <number>20</number>
+                       </property>
+                       <property name="value">
+                        <number>8</number>
                        </property>
                       </widget>
                      </item>
@@ -512,60 +5171,138 @@
                   </layout>
                  </widget>
                 </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_10">
+                  <item>
+                   <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
                </layout>
               </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_15">
+             <attribute name="title">
+              <string>Terminal</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_21">
               <item>
-               <widget class="QGroupBox" name="groupBox_38">
-                <property name="title">
-                 <string>Other Limits</string>
+               <widget class="QWidget" name="widget_2" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>1</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_36">
-                 <item row="0" column="0" rowspan="2" colspan="2">
-                  <widget class="QLabel" name="label_83">
-                   <property name="text">
-                    <string>Minimum duty cycle</string>
+                <layout class="QVBoxLayout" name="verticalLayout_4">
+                 <item>
+                  <widget class="QTextBrowser" name="terminalBrowser">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <family>Monospace</family>
+                    </font>
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="2" rowspan="2">
-                  <widget class="QLabel" name="label_84">
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_15">
+                   <item>
+                    <widget class="QLineEdit" name="terminalEdit"/>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="sendTerminalButton">
+                     <property name="text">
+                      <string>Send</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="clearTerminalButton">
+                     <property name="text">
+                      <string>Clear</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_23">
+             <attribute name="title">
+              <string>Firmware</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_18">
+              <item>
+               <widget class="QGroupBox" name="groupBox_23">
+                <property name="title">
+                 <string>Upload New Firmware</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_34">
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_81">
                    <property name="text">
-                    <string>Maximum duty cycle</string>
+                    <string>Path</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="3" rowspan="2">
-                  <widget class="QDoubleSpinBox" name="mcconfLimMaxDutyBox">
-                   <property name="decimals">
-                    <number>3</number>
+                 <item row="1" column="3">
+                  <widget class="QPushButton" name="firmwareUploadButton">
+                   <property name="text">
+                    <string>Upload</string>
                    </property>
-                   <property name="minimum">
-                    <double>0.010000000000000</double>
+                  </widget>
+                 </item>
+                 <item row="2" column="0" colspan="2">
+                  <widget class="QLabel" name="firmwareUploadStatusLabel">
+                   <property name="text">
+                    <string>FW Upload Status</string>
                    </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="2">
+                  <widget class="QProgressBar" name="firmwareBar">
                    <property name="maximum">
-                    <double>0.950000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
+                    <number>1000</number>
                    </property>
                    <property name="value">
-                    <double>0.950000000000000</double>
+                    <number>0</number>
                    </property>
                   </widget>
                  </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="mcconfLimMinDutyBox">
-                   <property name="decimals">
-                    <number>3</number>
+                 <item row="0" column="1">
+                  <widget class="QLineEdit" name="firmwareEdit"/>
+                 </item>
+                 <item row="1" column="2">
+                  <widget class="QPushButton" name="firmwareCancelButton">
+                   <property name="text">
+                    <string>Cancel</string>
                    </property>
-                   <property name="minimum">
-                    <double>0.005000000000000</double>
-                   </property>
-                   <property name="maximum">
-                    <double>0.500000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.005000000000000</double>
+                  </widget>
+                 </item>
+                 <item row="0" column="2" colspan="2">
+                  <widget class="QPushButton" name="firmwareChooseButton">
+                   <property name="text">
+                    <string>Choose...</string>
                    </property>
                   </widget>
                  </item>
@@ -573,57 +5310,27 @@
                </widget>
               </item>
               <item>
-               <spacer name="verticalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>17</width>
-                  <height>172</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_13">
-             <attribute name="title">
-              <string>BLDC</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_23">
-              <item>
-               <widget class="QGroupBox" name="groupBox_34">
+               <widget class="QGroupBox" name="groupBox_26">
                 <property name="title">
-                 <string>Sensor Mode</string>
+                 <string>Firmware Version</string>
                 </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_43">
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
                  <item>
-                  <widget class="QRadioButton" name="mcconfSensorModeSensorlessButton">
+                  <widget class="QLabel" name="label_82">
                    <property name="text">
-                    <string>Sensorless</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
+                    <string>Firmware version on connected VESC:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="mcconfSensorModeSensoredButton">
+                  <widget class="QLabel" name="firmwareVersionLabel">
                    <property name="text">
-                    <string>Sensored</string>
+                    <string>X.Y</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="mcconfSensorModeHybridButton">
-                   <property name="text">
-                    <string>Hybrid</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_20">
+                  <spacer name="horizontalSpacer_19">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
@@ -635,318 +5342,220 @@
                    </property>
                   </spacer>
                  </item>
+                 <item>
+                  <widget class="QPushButton" name="firmwareVersionReadButton">
+                   <property name="text">
+                    <string>Read Firmware Version</string>
+                   </property>
+                  </widget>
+                 </item>
                 </layout>
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_21">
-                <item>
-                 <widget class="QGroupBox" name="mcconfSlBox">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
+               <widget class="QGroupBox" name="groupBox_32">
+                <property name="title">
+                 <string>Supported Firmwares (for this version of BLDC Tool)</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_42">
+                 <item>
+                  <widget class="QLabel" name="firmwareSupportedLabel">
+                   <property name="text">
+                    <string>X.Y</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>508</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_3">
+             <attribute name="title">
+              <string>Rotor Position</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+              <item>
+               <layout class="QGridLayout" name="gridLayout_8">
+                <item row="0" column="0">
+                 <widget class="QPushButton" name="detectButton">
+                  <property name="text">
+                   <string>Inductance</string>
                   </property>
-                  <property name="title">
-                   <string>Sensorless</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>false</bool>
-                  </property>
-                  <property name="checked">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_12">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_26">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important for startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>Min ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSlMinErpmBox">
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_30">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For phase advance, not so important&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>BR ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSlBrErpmBox">
-                     <property name="maximum">
-                      <double>200000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>100.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_29">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For phase advance, not so important&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>Phase advance at BR ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSlIntLimScaleBrBox">
-                     <property name="maximum">
-                      <double>1.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.100000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_61">
-                     <property name="text">
-                      <string>Max brake current at dir change</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSlMaxFbCurrBox">
-                     <property name="maximum">
-                      <double>300.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
                  </widget>
                 </item>
-                <item>
-                 <widget class="QGroupBox" name="groupBox_16">
-                  <property name="title">
-                   <string>Sensorless - Commutation Mode</string>
+                <item row="0" column="7">
+                 <widget class="QPushButton" name="stopDetectButton">
+                  <property name="text">
+                   <string>Stop</string>
                   </property>
-                  <layout class="QGridLayout" name="gridLayout_46">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_100">
-                     <property name="text">
-                      <string>Comm Mode</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QRadioButton" name="mcconfCommIntButton">
-                     <property name="text">
-                      <string>Integrate</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QRadioButton" name="mcconfCommDelayButton">
-                     <property name="text">
-                      <string>Delay</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_28">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important. The detection function below can be used to determine this parameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>Integrator Limit</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1" colspan="2">
-                    <widget class="QDoubleSpinBox" name="mcconfSlIntLimBox">
-                     <property name="maximum">
-                      <double>2000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>1.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_27">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important for startup&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>Int Limit Min ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1" colspan="2">
-                    <widget class="QDoubleSpinBox" name="mcconfSlMinErpmIlBox">
-                     <property name="maximum">
-                      <double>10000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_41">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Important. The detection function below can be used to determine this parameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="text">
-                      <string>BEMF Coupling</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1" colspan="2">
-                    <widget class="QDoubleSpinBox" name="mcconfSlBemfKBox">
-                     <property name="maximum">
-                      <double>5000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
+                 </widget>
+                </item>
+                <item row="0" column="4">
+                 <widget class="QPushButton" name="detectPidPosErrorButton">
+                  <property name="text">
+                   <string>PID Pos Error</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QPushButton" name="detectEncoderButton">
+                  <property name="text">
+                   <string>Encoder</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QPushButton" name="detectObserverButton">
+                  <property name="text">
+                   <string>Observer</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="5">
+                 <widget class="QPushButton" name="detectEncoderObserverErrorButton">
+                  <property name="text">
+                   <string>Encoder Observer Error</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="6">
+                 <spacer name="horizontalSpacer_36">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QPushButton" name="detectPidPosButton">
+                  <property name="text">
+                   <string>PID Pos</string>
+                  </property>
                  </widget>
                 </item>
                </layout>
               </item>
               <item>
-               <widget class="QGroupBox" name="groupBox_12">
-                <property name="title">
-                 <string>Hall Sensors</string>
+               <widget class="QProgressBar" name="rotorPosBar">
+                <property name="maximum">
+                 <number>359</number>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_20">
+                <property name="value">
+                 <number>120</number>
+                </property>
+                <property name="format">
+                 <string>%v Degrees</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCustomPlot" name="realtimePlotPosition" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab_10">
+             <attribute name="title">
+              <string>Experiment</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_22">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <widget class="QLabel" name="experimentSampleLabel">
+                  <property name="text">
+                   <string>0 Samples</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="experimentClearSamplesButton">
+                  <property name="text">
+                   <string>Clear samples</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="experimentSaveSamplesButton">
+                  <property name="text">
+                   <string>Save samples to file...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTextBrowser" name="experimentBrowser"/>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="groupBox_6">
+                <property name="title">
+                 <string>Autosave Samples</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_11">
                  <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_22">
+                  <layout class="QHBoxLayout" name="horizontalLayout_13">
                    <item>
-                    <widget class="QLabel" name="label_31">
+                    <widget class="QLabel" name="label_14">
                      <property name="text">
-                      <string>Table</string>
+                      <string>Path</string>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <widget class="QSpinBox" name="mcconfHallTab0Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
+                    <widget class="QLineEdit" name="experimentPathEdit"/>
                    </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_8">
                    <item>
-                    <widget class="QSpinBox" name="mcconfHallTab1Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab2Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab3Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab4Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab5Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab6Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="mcconfHallTab7Box">
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>6</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="label_32">
+                    <widget class="QCheckBox" name="experimentAutosaveBox">
                      <property name="text">
-                      <string>Sensorless ERPM (hybrid mode)</string>
+                      <string>Use autosave</string>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <widget class="QDoubleSpinBox" name="mcconfHallSlErpmBox">
-                     <property name="maximum">
-                      <double>200000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                     <property name="value">
-                      <double>0.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_8">
+                    <spacer name="horizontalSpacer_5">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
                      </property>
@@ -958,5158 +5567,574 @@
                      </property>
                     </spacer>
                    </item>
-                  </layout>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>209</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_11">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="title">
-                 <string>Detect Parameters</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_24">
-                 <item>
-                  <layout class="QGridLayout" name="gridLayout_47">
-                   <item row="0" column="0">
-                    <widget class="QPushButton" name="mcconfDetectMotorParamButton">
+                   <item>
+                    <widget class="QLabel" name="label_13">
                      <property name="text">
-                      <string>Start detection</string>
+                      <string>Autosave every</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="0">
-                    <spacer name="verticalSpacer_5">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeType">
-                      <enum>QSizePolicy::Preferred</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>13</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QPushButton" name="mcconfDetectApplyButton">
-                     <property name="text">
-                      <string>Apply</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QGridLayout" name="gridLayout_7">
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfDetectCurrentBox">
-                     <property name="suffix">
-                      <string> A</string>
-                     </property>
-                     <property name="value">
-                      <double>6.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_44">
-                     <property name="text">
-                      <string>Min ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfDetectErpmBox">
-                     <property name="decimals">
-                      <number>1</number>
-                     </property>
-                     <property name="minimum">
-                      <double>10.000000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>10000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                     <property name="value">
-                      <double>600.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_42">
-                     <property name="toolTip">
-                      <string>The duty cycle at which the BEMF coupling is measured. A value between 0.03 and 0.15 usually works.</string>
-                     </property>
-                     <property name="text">
-                      <string>Low duty</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfDetectLowDutyBox">
-                     <property name="maximum">
-                      <double>0.400000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                     <property name="value">
-                      <double>0.050000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_43">
-                     <property name="text">
-                      <string>Current</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <widget class="QTextBrowser" name="mcconfDetectResultBrowser">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="html">
-                    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;Detection results will be printed here.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_24">
-             <attribute name="title">
-              <string>FOC</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_29">
-              <item>
-               <layout class="QGridLayout" name="gridLayout_42">
-                <item row="0" column="0">
-                 <widget class="QGroupBox" name="groupBox_39">
-                  <property name="title">
-                   <string>General</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_39">
-                   <item row="4" column="3">
-                    <widget class="QDoubleSpinBox" name="mcconfFocEncoderRatioBox">
-                     <property name="prefix">
-                      <string>Rat: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>500.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_89">
-                     <property name="text">
-                      <string>Current Control</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocCurrKpBox">
-                     <property name="prefix">
-                      <string>Kp: </string>
-                     </property>
-                     <property name="decimals">
-                      <number>4</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="3">
-                    <widget class="QDoubleSpinBox" name="mcconfFocCurrKiBox">
-                     <property name="prefix">
-                      <string>Ki: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="0">
-                    <widget class="QLabel" name="label_92">
-                     <property name="text">
-                      <string>Encoder</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocEncoderOffsetBox">
-                     <property name="prefix">
-                      <string>Ofs: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>360.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_101">
-                     <property name="text">
-                      <string>Sensor Mode</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="3">
-                    <widget class="QCheckBox" name="mcconfFocEncoderInvertedBox">
-                     <property name="text">
-                      <string>Invert Encoder</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2" colspan="2">
-                    <layout class="QHBoxLayout" name="horizontalLayout_26">
-                     <item>
-                      <widget class="QRadioButton" name="mcconfFocModeEncoderButton">
-                       <property name="text">
-                        <string>Encoder</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QRadioButton" name="mcconfFocModeHallButton">
-                       <property name="text">
-                        <string>Hall</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QRadioButton" name="mcconfFocModeSensorlessButton">
-                       <property name="text">
-                        <string>Sensorless</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                   <item row="5" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocSlErpmBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ERPM above which the hall sensors or encoder will be ignored and only the observer is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="maximum">
-                      <double>200000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="0">
-                    <widget class="QLabel" name="label_96">
-                     <property name="text">
-                      <string>Sensorless ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QGroupBox" name="groupBox_41">
-                  <property name="title">
-                   <string>General (cont)</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_40">
-                   <item row="7" column="0">
-                    <widget class="QLabel" name="label_104">
-                     <property name="text">
-                      <string>Openloop RPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocPllKpBox">
-                     <property name="prefix">
-                      <string>Kp: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocDutyDownrampKiBox">
-                     <property name="prefix">
-                      <string>Ki: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="0">
-                    <widget class="QLabel" name="label_103">
-                     <property name="text">
-                      <string>Duty Downramp</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocPllKiBox">
-                     <property name="prefix">
-                      <string>Ki: </string>
-                     </property>
-                     <property name="decimals">
-                      <number>2</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1000000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>1000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="5" column="0">
-                    <widget class="QLabel" name="label_90">
-                     <property name="text">
-                      <string>Speed Tracker</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="7" column="1" colspan="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocOpenloopRpmBox">
-                     <property name="keyboardTracking">
-                      <bool>false</bool>
-                     </property>
-                     <property name="prefix">
-                      <string/>
-                     </property>
-                     <property name="suffix">
-                      <string> RPM</string>
-                     </property>
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>10.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="6" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocDutyDownrampKpBox">
-                     <property name="prefix">
-                      <string>Kp: </string>
-                     </property>
-                     <property name="maximum">
-                      <double>10000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="1">
-                    <widget class="QSpinBox" name="mcconfFocFSwBox">
-                     <property name="toolTip">
-                      <string>Switching Frequency</string>
-                     </property>
-                     <property name="suffix">
-                      <string> Hz</string>
-                     </property>
-                     <property name="prefix">
-                      <string>F_SW: </string>
-                     </property>
-                     <property name="maximum">
-                      <number>100000</number>
-                     </property>
-                     <property name="singleStep">
-                      <number>100</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="0">
-                    <widget class="QLabel" name="label_94">
-                     <property name="text">
-                      <string>F_SW and DTc</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocDtCompBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dead time compensation. Getting this value right is important for the low speed performance of the sensorless observer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="prefix">
-                      <string>DTc: </string>
-                     </property>
-                     <property name="suffix">
-                      <string> µS</string>
-                     </property>
-                     <property name="decimals">
-                      <number>3</number>
-                     </property>
-                     <property name="maximum">
-                      <double>10000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QGroupBox" name="groupBox_40">
-                  <property name="title">
-                   <string>Motor Parameters (for Sensorless and Hall Operation)</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_41">
-                   <item row="4" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocObserverGainBox">
-                     <property name="maximum">
-                      <double>100000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>1.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="0">
-                    <widget class="QLabel" name="label_98">
-                     <property name="text">
-                      <string>Observer Gain (x1M)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="2">
-                    <widget class="QPushButton" name="mcconfFocObserverGainCalcButton">
-                     <property name="text">
-                      <string>Calc (Req: L)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QDoubleSpinBox" name="mcconfFocMotorRBox">
-                     <property name="prefix">
-                      <string>R: </string>
-                     </property>
-                     <property name="suffix">
-                      <string> Ω</string>
-                     </property>
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.001000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocMotorLBox">
-                     <property name="prefix">
-                      <string>L: </string>
-                     </property>
-                     <property name="suffix">
-                      <string> µH</string>
-                     </property>
-                     <property name="decimals">
-                      <number>2</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1000000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocMotorLinkageBox">
-                     <property name="prefix">
-                      <string>λ: </string>
-                     </property>
-                     <property name="decimals">
-                      <number>6</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QGroupBox" name="groupBox_43">
-                  <property name="title">
-                   <string>Sensorless Startup and Low Speed</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_44">
-                   <item row="1" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocDCurrentFactorBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum factor between the D axis and Q axis current.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="prefix">
-                      <string>Factor: </string>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.100000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocSlOpenloopHystBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the filtered RPM has been below openloop RPM for this amount of time, the motor will rotate in open loop with openloop RPM.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="prefix">
-                      <string>Hyst: </string>
-                     </property>
-                     <property name="suffix">
-                      <string> s</string>
-                     </property>
-                     <property name="decimals">
-                      <number>3</number>
-                     </property>
-                     <property name="maximum">
-                      <double>200.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.100000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_105">
-                     <property name="text">
-                      <string>Open Loop</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_107">
-                     <property name="text">
-                      <string>D Current Injection</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfFocDCurrentDutyBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Inject D axis current below this duty cycle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="prefix">
-                      <string>Duty: </string>
-                     </property>
-                     <property name="decimals">
-                      <number>3</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QDoubleSpinBox" name="mcconfFocSlOpenloopTimeBox">
-                     <property name="toolTip">
-                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Time to remain in open loop before entering closed loop.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                     <property name="prefix">
-                      <string>Time: </string>
-                     </property>
-                     <property name="suffix">
-                      <string> s</string>
-                     </property>
-                     <property name="decimals">
-                      <number>3</number>
-                     </property>
-                     <property name="maximum">
-                      <double>200.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.100000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_46">
-                <property name="title">
-                 <string>Hall Sensors</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_45">
-                 <item>
-                  <widget class="QLabel" name="label_95">
-                   <property name="text">
-                    <string>Table</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab0Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab1Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab2Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab3Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab4Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab5Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab6Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocHallTab7Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_23">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_17">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Expanding</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_44">
-                <property name="title">
-                 <string>Detect and Calculate Parameters</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_45">
-                 <item row="0" column="4">
-                  <spacer name="horizontalSpacer_29">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="3" column="1">
-                  <widget class="QDoubleSpinBox" name="mcconfFocCalcCCTcBox">
-                   <property name="prefix">
-                    <string>TC: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> µS</string>
-                   </property>
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>10.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>1000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QPushButton" name="mcconfFocMeasureLinkageButton">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spin up the motor using BLDC delay commutation and measure the flux linkage. The motor resistance is required to compensate for load, so it should be measured or entered first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Measure λ (Req: R)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QPushButton" name="mcconfFocMeasureRLButton">
-                   <property name="toolTip">
-                    <string>Measure the motor resistance and inductance.</string>
-                   </property>
-                   <property name="text">
-                    <string>Measure R and L</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectRBox">
-                   <property name="prefix">
-                    <string>R: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> Ω</string>
-                   </property>
-                   <property name="decimals">
-                    <number>5</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.001000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectLBox">
-                   <property name="prefix">
-                    <string>L: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> µH</string>
-                   </property>
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="5">
-                  <widget class="QPushButton" name="mcconfFocApplyRLLambdaButton">
-                   <property name="text">
-                    <string>Apply</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QPushButton" name="mcconfFocCalcCCButton">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Calculate Kp and Ki for the current control loop based on the motor resistance and inductance, and a desired time constant (TC) of the system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Calc CC (Req: R and L)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="5">
-                  <widget class="QPushButton" name="mcconfFocCalcCCApplyButton">
-                   <property name="text">
-                    <string>Apply</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="3">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectLinkageBox">
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                   <property name="prefix">
-                    <string>λ: </string>
-                   </property>
-                   <property name="decimals">
-                    <number>8</number>
-                   </property>
-                   <property name="maximum">
-                    <double>100.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.000100000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>0.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="3">
-                  <widget class="QDoubleSpinBox" name="mcconfFocCalcKiBox">
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                   <property name="prefix">
-                    <string>Ki: </string>
-                   </property>
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="2">
-                  <widget class="QDoubleSpinBox" name="mcconfFocCalcKpBox">
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                   <property name="prefix">
-                    <string>Kp: </string>
-                   </property>
-                   <property name="decimals">
-                    <number>4</number>
-                   </property>
-                   <property name="maximum">
-                    <double>1000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectCurrentBox">
-                   <property name="toolTip">
-                    <string>For measuring flux linkage:  The current to use.</string>
-                   </property>
-                   <property name="prefix">
-                    <string>I: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> A</string>
-                   </property>
-                   <property name="maximum">
-                    <double>150.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>6.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="2">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectDutyBox">
-                   <property name="toolTip">
-                    <string>For measuring flux linkage:  Duty cycle to measure flux linkage at.</string>
-                   </property>
-                   <property name="prefix">
-                    <string>Duty: </string>
-                   </property>
-                   <property name="maximum">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>0.500000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="3">
-                  <widget class="QDoubleSpinBox" name="mcconfFocDetectMinRpmBox">
-                   <property name="toolTip">
-                    <string>For measuring flux linkage: The minimum RPM to start the motor with.</string>
-                   </property>
-                   <property name="prefix">
-                    <string>RPM: </string>
-                   </property>
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <double>10000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>10.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>700.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="4" colspan="2">
-                  <widget class="QLabel" name="label_93">
-                   <property name="text">
-                    <string>← To spin up for λ</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_42">
-                <property name="title">
-                 <string>Detect Encoder</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_25">
-                 <item>
-                  <widget class="QPushButton" name="mcconfFocMeasureEncoderButton">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Run the motor slowly in open loop using the selected current and try to figure out the encoder offset and ratio, and whether the encoder is inverted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Measure</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderCurrentBox">
-                   <property name="prefix">
-                    <string>I: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> A</string>
-                   </property>
-                   <property name="value">
-                    <double>15.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_26">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderOffsetBox">
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                   <property name="prefix">
-                    <string>Ofs: </string>
-                   </property>
-                   <property name="suffix">
-                    <string/>
-                   </property>
-                   <property name="maximum">
-                    <double>360.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="mcconfFocMeasureEncoderRatioBox">
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                   <property name="prefix">
-                    <string>Rat: </string>
-                   </property>
-                   <property name="suffix">
-                    <string/>
-                   </property>
-                   <property name="maximum">
-                    <double>500.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="mcconfFocMeasureEncoderInvertedBox">
-                   <property name="text">
-                    <string>Invert Encoder</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_27">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="mcconfFocMeasureEncoderApplyButton">
-                   <property name="text">
-                    <string>Apply</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_45">
-                <property name="title">
-                 <string>Detect Hall Sensors</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_38">
-                 <item>
-                  <widget class="QPushButton" name="mcconfFocMeasureHallButton">
-                   <property name="text">
-                    <string>Measure</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="mcconfFocMeasureHallCurrentBox">
-                   <property name="prefix">
-                    <string>I: </string>
-                   </property>
-                   <property name="suffix">
-                    <string> A</string>
-                   </property>
-                   <property name="value">
-                    <double>15.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_25">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab0Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab1Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab2Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab3Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab4Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab5Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab6Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="mcconfFocMeasureHallTab7Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_24">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="mcconfFocMeasureHallApplyButton">
-                   <property name="text">
-                    <string>Apply</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_14">
-             <attribute name="title">
-              <string>Advanced</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_27">
-              <item>
-               <widget class="QGroupBox" name="groupBox_13">
-                <property name="title">
-                 <string>PWM mode (DC and BLDC only)</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_44">
-                 <item>
-                  <widget class="QRadioButton" name="mcconfPwmModeSyncButton">
-                   <property name="text">
-                    <string>Synchronous</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="mcconfPwmModeBipolarButton">
-                   <property name="text">
-                    <string>Bipolar</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="mcconfPwmModeNonsyncHiswButton">
-                   <property name="text">
-                    <string>Nonsynchronous-HISW (Not recommended)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_21">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_23">
-                <item>
-                 <widget class="QGroupBox" name="groupBox_14">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="title">
-                   <string>Current control</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_14">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_34">
-                     <property name="text">
-                      <string>Startup boost (BLDC only)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfCcBoostBox">
-                     <property name="decimals">
-                      <number>3</number>
-                     </property>
-                     <property name="maximum">
-                      <double>1.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_35">
-                     <property name="text">
-                      <string>Min current</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfCcMinBox"/>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_36">
-                     <property name="toolTip">
-                      <string>Only change this if you know what you are doing</string>
-                     </property>
-                     <property name="text">
-                      <string>Gain (BLDC and DC only)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfCcGainBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="maximum">
-                      <double>50.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <spacer name="verticalSpacer_16">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeType">
-                      <enum>QSizePolicy::Preferred</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>25</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="groupBox_37">
-                  <property name="title">
-                   <string>Backoff and ramping (DC and BLDC only)</string>
-                  </property>
-                  <property name="flat">
-                   <bool>false</bool>
-                  </property>
-                  <property name="checkable">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_37">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_3">
-                     <property name="text">
-                      <string>Duty ramp step (at 1 kHz)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfMDutyRampStepBox">
-                     <property name="decimals">
-                      <number>4</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_69">
-                     <property name="text">
-                      <string>Max current ramp step (at 1 kHz)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfCcMaxRampStepBox">
-                     <property name="decimals">
-                      <number>4</number>
-                     </property>
-                     <property name="maximum">
-                      <double>50.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_85">
-                     <property name="text">
-                      <string>Current backoff gain</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfMCurrentBackoffGainBox">
-                     <property name="decimals">
-                      <number>4</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.010000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_33">
-                     <property name="text">
-                      <string>Speed limit ramp step</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfMDutyRampStepSpeedLimBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_39">
-                <item>
-                 <widget class="QGroupBox" name="groupBox_15">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="title">
-                   <string>Speed control</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_15">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_37">
-                     <property name="text">
-                      <string>KP</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSpidKpBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_38">
-                     <property name="text">
-                      <string>KI</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSpidKiBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_39">
-                     <property name="text">
-                      <string>KD</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSpidKdBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_40">
-                     <property name="text">
-                      <string>MIN ERPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfSpidMinRpmBox">
-                     <property name="maximum">
-                      <double>200000.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>100.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="groupBox_30">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="title">
-                   <string>Position control</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_26">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_68">
-                     <property name="text">
-                      <string>KP</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfPpidKiBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_70">
-                     <property name="text">
-                      <string>KI</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfPpidKdBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QLabel" name="label_71">
-                     <property name="text">
-                      <string>KD</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfPpidKpBox">
-                     <property name="decimals">
-                      <number>5</number>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.000100000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_11">
-                     <property name="text">
-                      <string>Angle division</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QDoubleSpinBox" name="mcconfPpidAngDivBox">
-                     <property name="minimum">
-                      <double>0.010000000000000</double>
-                     </property>
-                     <property name="maximum">
-                      <double>10000.000000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_53">
-                <item>
-                 <widget class="QGroupBox" name="groupBox_17">
-                  <property name="title">
-                   <string>Misc</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_38">
-                   <item row="0" column="1">
-                    <widget class="QLabel" name="label_4">
-                     <property name="text">
-                      <string>Fault stop time</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QSpinBox" name="mcconfMEncoderCountBox">
+                   <item>
+                    <widget class="QSpinBox" name="experimentAutosaveIntervalBox">
                      <property name="maximum">
                       <number>1000000</number>
                      </property>
-                     <property name="singleStep">
-                      <number>100</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QSpinBox" name="mcconfMFaultStopTimeBox">
-                     <property name="suffix">
-                      <string> ms</string>
-                     </property>
-                     <property name="minimum">
-                      <number>-1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>40000000</number>
-                     </property>
-                     <property name="singleStep">
-                      <number>500</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QLabel" name="label_91">
-                     <property name="text">
-                      <string>Encoder Counts</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="groupBox_3">
-                  <property name="title">
-                   <string>Hall/encoder port mode</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_43">
-                   <item row="0" column="0">
-                    <widget class="QRadioButton" name="mcconfMSensorHallButton">
-                     <property name="text">
-                      <string>Hall sensors</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QRadioButton" name="mcconfMSensorAsSpiButton">
-                     <property name="text">
-                      <string>AS5047/AS5048 SPI</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QRadioButton" name="mcconfMSensorAbiButton">
-                     <property name="text">
-                      <string>ABI encoder</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_22">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_8">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_4">
-             <attribute name="title">
-              <string>Description</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_25">
-              <item>
-               <widget class="MRichTextEdit" name="mcconfDescEdit" native="true"/>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_17">
-            <item>
-             <widget class="QPushButton" name="mcconfReadButton">
-              <property name="text">
-               <string>Read configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mcconfReadDefaultButton">
-              <property name="text">
-               <string>Read default configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mcconfWriteButton">
-              <property name="text">
-               <string>Write configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mcconfLoadXmlButton">
-              <property name="text">
-               <string>Load XML</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mcconfSaveXmlButton">
-              <property name="text">
-               <string>Save XML</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_5">
-         <attribute name="title">
-          <string>App Configuration</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_33">
-          <item>
-           <widget class="QTabWidget" name="tabWidget_3">
-            <property name="tabPosition">
-             <enum>QTabWidget::West</enum>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="tab_16">
-             <attribute name="title">
-              <string>General</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_3">
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_5">
-                <item>
-                 <widget class="QGroupBox" name="groupBox_28">
-                  <property name="title">
-                   <string>Settings</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_29">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_65">
-                     <property name="text">
-                      <string>Controller ID</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QSpinBox" name="appconfControllerIdBox">
-                     <property name="maximum">
-                      <number>255</number>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="appconfSendCanStatusBox">
-                  <property name="title">
-                   <string>Send status over CAN</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>true</bool>
-                  </property>
-                  <property name="checked">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_25">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_12">
-                     <property name="text">
-                      <string>Rate (Hz)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QSpinBox" name="appconfSendCanStatusRateBox">
-                     <property name="maximum">
+                     <property name="value">
                       <number>1000</number>
                      </property>
                     </widget>
                    </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_18">
-                <property name="title">
-                 <string>App to use (Changing this requires a reboot)</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_33">
-                 <item>
-                  <layout class="QGridLayout" name="gridLayout_22">
-                   <item row="1" column="0">
-                    <widget class="QRadioButton" name="appconfUseUartButton">
+                   <item>
+                    <widget class="QLabel" name="label_15">
                      <property name="text">
-                      <string>UART</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QRadioButton" name="appconfUsePpmUartButton">
-                     <property name="text">
-                      <string>PPM and UART</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="2">
-                    <widget class="QRadioButton" name="appconfUseCustomButton">
-                     <property name="text">
-                      <string>Custom user application</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QRadioButton" name="appconfUseNoAppButton">
-                     <property name="text">
-                      <string>No app</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QRadioButton" name="appconfUseNrfButton">
-                     <property name="text">
-                      <string>NRF</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <widget class="QRadioButton" name="appconfUseNunchukButton">
-                     <property name="text">
-                      <string>Nunchuk</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QRadioButton" name="appconfUsePpmButton">
-                     <property name="text">
-                      <string>PPM</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QRadioButton" name="appconfUseAdcButton">
-                     <property name="text">
-                      <string>ADC</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QRadioButton" name="appconfUseAdcUartButton">
-                     <property name="text">
-                      <string>ADC and UART</string>
+                      <string>samples</string>
                      </property>
                     </widget>
                    </item>
                   </layout>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_12">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>561</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
                  </item>
                 </layout>
                </widget>
               </item>
               <item>
-               <widget class="QGroupBox" name="groupBox_22">
+               <widget class="QGroupBox" name="groupBox_35">
                 <property name="title">
-                 <string>Timeout (when no control signal is received)</string>
+                 <string>Servo Output</string>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_18">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_52">
-                   <property name="text">
-                    <string>Timeout (ms)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="appconfTimeoutBox">
+                <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <item>
+                  <widget class="QSlider" name="servoOutputSlider">
                    <property name="maximum">
-                    <number>30000</number>
+                    <number>1000</number>
                    </property>
-                   <property name="singleStep">
+                   <property name="value">
                     <number>500</number>
                    </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_53">
-                   <property name="text">
-                    <string>Brake current to use when a timeout occurs (A)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfTimeoutBrakeCurrentBox">
-                   <property name="maximum">
-                    <double>200.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_3">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>396</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_17">
-             <attribute name="title">
-              <string>PPM</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_35">
-              <item>
-               <widget class="QGroupBox" name="groupBox_19">
-                <property name="title">
-                 <string>Control mode</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_28">
-                 <item>
-                  <layout class="QGridLayout" name="gridLayout_13">
-                   <item row="0" column="2">
-                    <widget class="QRadioButton" name="appconfPpmDutyNorevButton">
-                     <property name="text">
-                      <string>Duty cycle no reverse</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QRadioButton" name="appconfPpmDutyButton">
-                     <property name="text">
-                      <string>Duty cycle</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QRadioButton" name="appconfPpmDisabledButton">
-                     <property name="text">
-                      <string>Disabled</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="3">
-                    <widget class="QRadioButton" name="appconfPpmPidNorevButton">
-                     <property name="text">
-                      <string>PID speed control no reverse</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QRadioButton" name="appconfPpmCurrentNorevBrakeButton">
-                     <property name="text">
-                      <string>Current no reverse with brake</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="3">
-                    <widget class="QRadioButton" name="appconfPpmCurrentButton">
-                     <property name="text">
-                      <string>Current</string>
-                     </property>
-                     <property name="checked">
-                      <bool>false</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QRadioButton" name="appconfPpmCurrentNorevButton">
-                     <property name="text">
-                      <string>Current no reverse</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QRadioButton" name="appconfPpmPidButton">
-                     <property name="text">
-                      <string>PID speed control</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_10">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>411</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_20">
-                <property name="title">
-                 <string>Settings</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_17">
-                 <item row="4" column="0">
-                  <widget class="QCheckBox" name="appconfPpmMedianFilterBox">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a median filter to reject niose. This will introduce one sample delay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Use Median Filter</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QLabel" name="label_51">
-                   <property name="text">
-                    <string>Maximum Pulsewidth (ms)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmPidMaxErpmBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_49">
-                   <property name="text">
-                    <string>Deadband</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmPulseStartBox">
-                   <property name="maximum">
-                    <double>10.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="label_50">
-                   <property name="text">
-                    <string>Minimum Pulsewidth (ms)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmPulseWidthBox">
-                   <property name="maximum">
-                    <double>20.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_45">
-                   <property name="text">
-                    <string>PID max ERPM</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmHystBox">
-                   <property name="maximum">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.050000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="5" column="0">
-                  <widget class="QCheckBox" name="appconfPpmSafeStartBox">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Don't give throttle unless the received output has been 0 for at leas 50 pulses. The counter is reset on boot, every time a new configuration is loaded and when a timeout occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Safe Start</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfPpmRpmLimBox">
-                <property name="title">
-                 <string>Soft RPM limit (current mode only)</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_20">
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmRpmLimStartBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_47">
-                   <property name="text">
-                    <string>ERPM limit start</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_48">
-                   <property name="text">
-                    <string>ERPM limit end</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfPpmRpmLimEndBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfPpmMultiGroup">
-                <property name="title">
-                 <string>Multiple ESCs over CAN</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_37">
-                 <item>
-                  <widget class="QCheckBox" name="appconfPpmTcBox">
-                   <property name="text">
-                    <string>Enable Traction Control (current mode only)</string>
-                   </property>
-                   <property name="checked">
+                   <property name="invertedAppearance">
                     <bool>false</bool>
                    </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_14">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_67">
-                   <property name="text">
-                    <string>Traction Control ERPM diff</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="appconfPpmTcErpmBox">
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>3000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfUpdatePpmBox">
-                <property name="title">
-                 <string>Display</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_19">
-                 <item row="0" column="0">
-                  <widget class="QProgressBar" name="appconfDecodedPpmBar">
-                   <property name="minimum">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <number>1000</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                   <property name="format">
-                    <string>%p%</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QLCDNumber" name="appconfPpmPulsewidthNumber"/>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLabel" name="label_80">
-                   <property name="text">
-                    <string>Pulsewidth (ms):</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>221</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_22">
-             <attribute name="title">
-              <string>ADC</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_16">
-              <item>
-               <widget class="QGroupBox" name="groupBox_31">
-                <property name="title">
-                 <string>Control mode</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_40">
-                 <item>
-                  <layout class="QGridLayout" name="gridLayout_30">
-                   <item row="0" column="3">
-                    <widget class="QRadioButton" name="appconfAdcCurrentButtonButton">
-                     <property name="text">
-                      <string>Current button</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QRadioButton" name="appconfAdcDisabledButton">
-                     <property name="text">
-                      <string>Disabled</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="4">
-                    <widget class="QRadioButton" name="appconfAdcCurrentNorevCenterButton">
-                     <property name="text">
-                      <string>Current norev center</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QRadioButton" name="appconfAdcCurrentNorevButtonButton">
-                     <property name="text">
-                      <string>Current norev button</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QRadioButton" name="appconfAdcCurrentButton">
-                     <property name="text">
-                      <string>Current</string>
-                     </property>
-                     <property name="checked">
-                      <bool>false</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QRadioButton" name="appconfAdcCurrentCenterButton">
-                     <property name="text">
-                      <string>Current center</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="4">
-                    <widget class="QRadioButton" name="appconfAdcDutyCycleButtonButton">
-                     <property name="text">
-                      <string>Duty cycle button</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="3">
-                    <widget class="QRadioButton" name="appconfAdcDutyCycleCenterButton">
-                     <property name="text">
-                      <string>Duty cycle center</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QRadioButton" name="appconfAdcDutyCycleButton">
-                     <property name="text">
-                      <string>Duty cycle</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QRadioButton" name="appconfAdcCurrentNorevAdcButton">
-                     <property name="text">
-                      <string>Current norev ADC2</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_16">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>411</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_33">
-                <property name="title">
-                 <string>Settings</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_33">
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="appconfAdcUpdateRateBox">
-                   <property name="suffix">
-                    <string> Hz</string>
-                   </property>
-                   <property name="maximum">
-                    <number>10000</number>
-                   </property>
-                   <property name="singleStep">
-                    <number>10</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfAdcHystBox">
-                   <property name="maximum">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.050000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_78">
-                   <property name="text">
-                    <string>Update Rate</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="5">
-                  <widget class="QCheckBox" name="appconfAdcFilterBox">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use a median filter to reject niose. This will introduce one sample delay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Use Filter</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_76">
-                   <property name="text">
-                    <string>Deadband</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="5">
-                  <widget class="QCheckBox" name="appconfAdcSafeStartBox">
-                   <property name="toolTip">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Don't give throttle unless the received output has been 0 for at leas 50 pulses. The counter is reset on boot, every time a new configuration is loaded and when a timeout occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string>Safe Start</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QWidget" name="widget" native="true">
-                   <property name="minimumSize">
-                    <size>
-                     <width>50</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="7">
-                  <spacer name="horizontalSpacer_18">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="0" column="4">
-                  <widget class="QDoubleSpinBox" name="appconfAdcVoltageStartBox">
-                   <property name="suffix">
-                    <string> V</string>
-                   </property>
-                   <property name="maximum">
-                    <double>10.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="3">
-                  <widget class="QLabel" name="label_77">
-                   <property name="text">
-                    <string>Minimum Voltage</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="3">
-                  <widget class="QLabel" name="label_75">
-                   <property name="text">
-                    <string>Maximum Voltage</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="4">
-                  <widget class="QDoubleSpinBox" name="appconfAdcVoltageEndBox">
-                   <property name="suffix">
-                    <string> V</string>
-                   </property>
-                   <property name="maximum">
-                    <double>20.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.010000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="6">
-                  <widget class="QCheckBox" name="appconfAdcInvertVoltageBox">
-                   <property name="text">
-                    <string>Invert Voltage</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_36">
-                <property name="title">
-                 <string>Buttons</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_35">
-                 <item row="2" column="0">
-                  <widget class="QCheckBox" name="appconfAdcInvertRevButtonBox">
-                   <property name="text">
-                    <string>Invert reverse button</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QCheckBox" name="appconfAdcInvertCcButtonBox">
-                   <property name="text">
-                    <string>Invert cruise control button</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="4" column="0">
-                  <spacer name="verticalSpacer_12">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item row="2" column="1" rowspan="3">
-                  <widget class="QTextBrowser" name="textBrowser_2">
-                   <property name="html">
-                    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;The cruise control button will maintain the current speed while pressed when current control is used and no throttle is given. The reverse button is used to reverse the throttle when one of the corresponding control modes is used.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;When only the ADC app is used, the TX pin is used for the cruise control button and the RX pin is used for the reverse button. When the ADC and UART apps are used at the same time, the servo input will be used as the button. In this case it will be used for the reverse button when a control mode with button is selected, otherwise it will be used for the cruise control button.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfAdcRpmLimBox">
-                <property name="title">
-                 <string>Soft RPM limit (current mode only)</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_32">
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfAdcRpmLimStartBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_73">
-                   <property name="text">
-                    <string>ERPM limit start</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="4">
-                  <widget class="QDoubleSpinBox" name="appconfAdcRpmLimEndBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="3">
-                  <widget class="QLabel" name="label_74">
-                   <property name="text">
-                    <string>ERPM limit end</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <spacer name="horizontalSpacer_28">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfAdcMultiGroup">
-                <property name="title">
-                 <string>Multiple ESCs over CAN</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_41">
-                 <item>
-                  <widget class="QCheckBox" name="appconfAdcTcBox">
-                   <property name="text">
-                    <string>Enable Traction Control (current mode only)</string>
-                   </property>
-                   <property name="checked">
+                   <property name="invertedControls">
                     <bool>false</bool>
                    </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_17">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_72">
-                   <property name="text">
-                    <string>Traction Control ERPM diff</string>
+                   <property name="tickPosition">
+                    <enum>QSlider::NoTicks</enum>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QDoubleSpinBox" name="appconfAdcTcErpmBox">
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
+                  <widget class="QLCDNumber" name="servoOutputNumber">
+                   <property name="digitCount">
+                    <number>5</number>
                    </property>
-                   <property name="value">
-                    <double>3000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfAdcUpdateBox">
-                <property name="title">
-                 <string>Display</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_31">
-                 <item row="0" column="0">
-                  <widget class="QProgressBar" name="appconfAdcDecodedBar">
-                   <property name="minimum">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <number>1000</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                   <property name="format">
-                    <string>%p%</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QLCDNumber" name="appconfAdcVoltageNumber">
                    <property name="value" stdset="0">
-                    <double>0.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLabel" name="label_79">
-                   <property name="text">
-                    <string>ADC (V):</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QProgressBar" name="appconfAdcDecodedBar2">
-                   <property name="maximum">
-                    <number>1000</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QLabel" name="lblVoltage2">
-                   <property name="text">
-                    <string>ADC2 (V):</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QLCDNumber" name="appconfAdcVoltageNumber2"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_14">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>76</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_18">
-             <attribute name="title">
-              <string>UART</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_36">
-              <item>
-               <widget class="QGroupBox" name="groupBox_21">
-                <property name="title">
-                 <string>Settings</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_16">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_46">
-                   <property name="text">
-                    <string>Baud rate</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="appconfUartBaudBox">
-                   <property name="maximum">
-                    <number>20000000</number>
-                   </property>
-                   <property name="singleStep">
-                    <number>2400</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_10">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>470</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_21">
-             <attribute name="title">
-              <string>Nunchuk</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_32">
-              <item>
-               <widget class="QGroupBox" name="groupBox_24">
-                <property name="title">
-                 <string>Control mode</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_31">
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_35">
-                   <item>
-                    <widget class="QRadioButton" name="appconfChukDisabledButton">
-                     <property name="text">
-                      <string>Disabled</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QRadioButton" name="appconfChukCurrentNorevButton">
-                     <property name="text">
-                      <string>Current</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QRadioButton" name="appconfChukCurrentButton">
-                     <property name="text">
-                      <string>Current with reverse</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_11">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>720</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_25">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="title">
-                 <string>Settings</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_21">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_54">
-                   <property name="text">
-                    <string>Deadband</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfChukHystBox">
-                   <property name="maximum">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.050000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QLabel" name="label_63">
-                   <property name="text">
-                    <string>Positive ramping time constant</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="3">
-                  <widget class="QDoubleSpinBox" name="appconfChukRampTimePosBox">
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>1.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_56">
-                   <property name="text">
-                    <string>ERPM limit start</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfChukRpmLimStartBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QLabel" name="label_64">
-                   <property name="text">
-                    <string>Negative ramping time constant</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="3">
-                  <widget class="QDoubleSpinBox" name="appconfChukRampTimeNegBox">
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                   <property name="value">
                     <double>0.500000000000000</double>
                    </property>
                   </widget>
                  </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="label_55">
-                   <property name="text">
-                    <string>ERPM limit end</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QDoubleSpinBox" name="appconfChukRpmLimEndBox">
-                   <property name="maximum">
-                    <double>200000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="2">
-                  <widget class="QLabel" name="label_88">
-                   <property name="text">
-                    <string>ERPM/S input in cruise control</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="3">
-                  <widget class="QDoubleSpinBox" name="appconfChukErpmPerSBox">
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>100.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>3000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
                 </layout>
-                <zorder>label_56</zorder>
-                <zorder>appconfChukRpmLimStartBox</zorder>
-                <zorder>label_54</zorder>
-                <zorder>appconfChukHystBox</zorder>
-                <zorder>label_55</zorder>
-                <zorder>appconfChukRpmLimEndBox</zorder>
-                <zorder>label_63</zorder>
-                <zorder>appconfChukRampTimePosBox</zorder>
-                <zorder>label_64</zorder>
-                <zorder>appconfChukRampTimeNegBox</zorder>
-                <zorder>label_88</zorder>
-                <zorder>appconfChukErpmPerSBox</zorder>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfChukMultiGroup">
-                <property name="title">
-                 <string>Multiple ESCs over CAN</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_36">
-                 <item>
-                  <widget class="QCheckBox" name="appconfChukTcBox">
-                   <property name="text">
-                    <string>Enable Traction Control</string>
-                   </property>
-                   <property name="checked">
-                    <bool>false</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_13">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_66">
-                   <property name="text">
-                    <string>Traction Control ERPM diff</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="appconfChukTcErpmBox">
-                   <property name="maximum">
-                    <double>100000.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>3000.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="appconfUpdateChukBox">
-                <property name="title">
-                 <string>Display</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>false</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_32">
-                 <item>
-                  <widget class="QProgressBar" name="appconfDecodedChukBar">
-                   <property name="minimum">
-                    <number>0</number>
-                   </property>
-                   <property name="maximum">
-                    <number>1000</number>
-                   </property>
-                   <property name="value">
-                    <number>0</number>
-                   </property>
-                   <property name="format">
-                    <string>%p%</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QTextBrowser" name="textBrowser">
-                <property name="html">
-                 <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;This has been tested with the wireless Nyko Kama nunchuk. The receiver can be connected directly to the I2C port on the ESC. The y-axis on the joystick is used for acceleration/braking. The buttons have the following functions:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;C-Button:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;Cruise control. If the C-button is pressed, the ESC will maintail the current speed with a PID control loop. The joystick can still be used to accelerate and brake, but as soon as it is returned to the center position the new speed will be maintained, as long as the C-button remains pressed.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;Z-Button:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;The Z-button is used to change the direction of the motor if reverse is activated. Without reverse, Z has no effect.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;There is also a safety function. If nothing received from the nunchuk (including the accelerometers) changes for longer than the timeout value in the &lt;/span&gt;&lt;span style=&quot; font-size:11pt; font-style:italic;&quot;&gt;General&lt;/span&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt; tab, the timeout function will be activated and either release the motor or brake with the current specified next to the timeout value.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_25">
-             <attribute name="title">
-              <string>NRF</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_37">
-              <item>
-               <widget class="QGroupBox" name="groupBox_47">
-                <property name="title">
-                 <string>Speed</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_46">
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfSpeed250kButton">
-                   <property name="text">
-                    <string>250K</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfSpeed1mButton">
-                   <property name="text">
-                    <string>1M</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfSpeed2mButton">
-                   <property name="text">
-                    <string>2M</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_33">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_48">
-                <property name="title">
-                 <string>Power</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_47">
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfPowerM18Button">
-                   <property name="text">
-                    <string>-18 dBm</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfPowerM12Button">
-                   <property name="text">
-                    <string>-12 dBm</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfPowerM6Button">
-                   <property name="text">
-                    <string>-6 dBm</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfPower0Button">
-                   <property name="text">
-                    <string>0 dBm</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_31">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_50">
-                <property name="title">
-                 <string>CRC</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_49">
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfCrc1BButton">
-                   <property name="text">
-                    <string>1 Byte</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="appconfNrfCrc2BButton">
-                   <property name="text">
-                    <string>2 Byte</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_32">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_49">
-                <property name="title">
-                 <string>Ack Retry</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_48">
-                 <item>
-                  <widget class="QCheckBox" name="appconfNrfUseAckBox">
-                   <property name="text">
-                    <string>Use Ack</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_97">
-                   <property name="text">
-                    <string>Retries</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="appconfNrfRetrBox">
-                   <property name="maximum">
-                    <number>15</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_99">
-                   <property name="text">
-                    <string>Delay</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="appconfNrfRetrDelayBox">
-                   <property name="currentIndex">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>250 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>500 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>750 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>1000 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>1250 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>1500 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>1750 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>2000 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>2250 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>2500 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>2750 µs</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3000 µS</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3250 µS</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3500 µS</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3750 µS</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>4000 µS</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_30">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_51">
-                <property name="title">
-                 <string>Channel</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_50">
-                 <item>
-                  <widget class="QSpinBox" name="appconfNrfChannelBox">
-                   <property name="maximum">
-                    <number>125</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_34">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>836</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="groupBox_52">
-                <property name="title">
-                 <string>Address</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_51">
-                 <item>
-                  <widget class="QSpinBox" name="appconfNrfAddrB0Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="appconfNrfAddrB1Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="appconfNrfAddrB2Box">
-                   <property name="maximum">
-                    <number>255</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_35">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>710</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_18">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>213</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_27">
-            <item>
-             <widget class="QPushButton" name="appconfReadButton">
-              <property name="text">
-               <string>Read configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="appconfReadDefaultButton">
-              <property name="text">
-               <string>Read default configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="appconfWriteButton">
-              <property name="text">
-               <string>Write configuration</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_9">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_6">
-         <attribute name="title">
-          <string>Realtime Data</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_17">
-          <item>
-           <widget class="QTabWidget" name="tabWidget_5">
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="tab_19">
-             <attribute name="title">
-              <string>Current/Duty</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_29">
-              <item>
-               <widget class="QCustomPlot" name="realtimePlotRest" native="true"/>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_20">
-             <attribute name="title">
-              <string>Temperatures</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_30">
-              <item>
-               <widget class="QCustomPlot" name="realtimePlotTemperature" native="true">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_28">
-             <attribute name="title">
-              <string>RPM</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_52">
-              <item>
-               <widget class="QCustomPlot" name="realtimePlotRpm" native="true"/>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <widget class="RtDataWidget" name="rtDataWidget" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>140</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_16">
-            <item>
-             <widget class="QCheckBox" name="realtimeAutoScaleBox">
-              <property name="text">
-               <string>Auto Scale</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="realtimeActivateBox">
-              <property name="text">
-               <string>Activate sampling</string>
-              </property>
-              <property name="tristate">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_7">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_2">
-         <attribute name="title">
-          <string>BEMF Plot</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_10">
-          <item>
-           <widget class="QCustomPlot" name="voltagePlot" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QCheckBox" name="showPh1Box">
-              <property name="text">
-               <string>Phase 1</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showPh2Box">
-              <property name="text">
-               <string>Phase 2</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showPh3Box">
-              <property name="text">
-               <string>Phase 3</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showVirtualGndBox">
-              <property name="text">
-               <string>Virtual Ground</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showPosVoltageBox">
-              <property name="text">
-               <string>Position</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="truncateBox">
-              <property name="text">
-               <string>Truncate non-conducting phases</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab">
-         <attribute name="title">
-          <string>Current Plot</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_19">
-          <item>
-           <widget class="QTabWidget" name="tabWidget_2">
-            <property name="tabPosition">
-             <enum>QTabWidget::West</enum>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="tab_7">
-             <attribute name="title">
-              <string>Plot</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_8">
-              <item>
-               <widget class="QCustomPlot" name="currentPlot" native="true">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_14">
-                <item>
-                 <widget class="QCheckBox" name="showCurrent1Box">
-                  <property name="text">
-                   <string>Current 1</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="showCurrent2Box">
-                  <property name="text">
-                   <string>Current 2</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="showCurrent3Box">
-                  <property name="text">
-                   <string>Current 3</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="showTotalCurrentBox">
-                  <property name="text">
-                   <string>Total current</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="showMcTotalCurrentBox">
-                  <property name="text">
-                   <string>MC total current</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="showPosCurrentBox">
-                  <property name="text">
-                   <string>Position</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="currentTimeButton">
-                  <property name="text">
-                   <string>Time</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QRadioButton" name="currentSpectrumButton">
-                  <property name="text">
-                   <string>Spectrum</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_8">
-             <attribute name="title">
-              <string>Filter 1</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_12">
-              <item>
-               <widget class="QSplitter" name="splitter">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <widget class="QWidget" name="layoutWidget">
-                 <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <item>
-                   <widget class="QCustomPlot" name="filterResponsePlot" native="true"/>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="filterLogScaleBox">
-                    <property name="text">
-                     <string>Logscale</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="layoutWidget_12">
-                 <layout class="QVBoxLayout" name="verticalLayout_9">
-                  <item>
-                   <widget class="QCustomPlot" name="filterPlot" native="true"/>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="filterScatterBox">
-                    <property name="text">
-                     <string>Scatterplot</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="tab_9">
-             <attribute name="title">
-              <string>Filter 2</string>
-             </attribute>
-             <layout class="QVBoxLayout" name="verticalLayout_15">
-              <item>
-               <widget class="QSplitter" name="splitter_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <widget class="QWidget" name="layoutWidget_10">
-                 <layout class="QVBoxLayout" name="verticalLayout_13">
-                  <item>
-                   <widget class="QCustomPlot" name="filterResponsePlot2" native="true"/>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="filterLogScaleBox2">
-                    <property name="text">
-                     <string>Logscale</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="layoutWidget2_2">
-                 <layout class="QVBoxLayout" name="verticalLayout_14">
-                  <item>
-                   <widget class="QCustomPlot" name="filterPlot2" native="true"/>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="filterScatterBox2">
-                    <property name="text">
-                     <string>Scatterplot</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
                </widget>
               </item>
              </layout>
             </widget>
            </widget>
           </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QGroupBox" name="groupBox_4">
-              <property name="title">
-               <string>Filter 1</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_4">
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="currentFilterActiveBox">
-                 <property name="text">
-                  <string>Activate</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                 <item>
-                  <widget class="QRadioButton" name="firRadioButton">
-                   <property name="text">
-                    <string>FIR</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="meanRadioButton">
-                   <property name="text">
-                    <string>Mean value</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="compDelayBox">
-                 <property name="text">
-                  <string>Delay Comp</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1" rowspan="2">
-                <layout class="QGridLayout" name="gridLayout_3">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_6">
-                   <property name="text">
-                    <string>Stop Frequency</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="currentFilterFreqBox">
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>0.500000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.005000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>0.050000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_7">
-                   <property name="text">
-                    <string>Filter Taps (2^)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QSpinBox" name="currentFilterTapBox">
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>10</number>
-                   </property>
-                   <property name="value">
-                    <number>6</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="hammingBox">
-                 <property name="text">
-                  <string>Hammnig</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_7">
-              <property name="title">
-               <string>Filter 2</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_5">
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="currentFilterActiveBox2">
-                 <property name="text">
-                  <string>Activate</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_11">
-                 <item>
-                  <widget class="QRadioButton" name="firRadioButton2">
-                   <property name="text">
-                    <string>FIR</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="meanRadioButton2">
-                   <property name="text">
-                    <string>Mean value</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="1" rowspan="2">
-                <layout class="QGridLayout" name="gridLayout_6">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_8">
-                   <property name="text">
-                    <string>Stop Frequency</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QDoubleSpinBox" name="currentFilterFreqBox2">
-                   <property name="decimals">
-                    <number>3</number>
-                   </property>
-                   <property name="maximum">
-                    <double>0.500000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.005000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>0.050000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_9">
-                   <property name="text">
-                    <string>Filter Taps (2^)</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QSpinBox" name="currentFilterTapBox2">
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>10</number>
-                   </property>
-                   <property name="value">
-                    <number>6</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="hammingBox2">
-                 <property name="text">
-                  <string>Hamming</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_12">
-                 <item>
-                  <widget class="QLabel" name="label_10">
-                   <property name="text">
-                    <string>Decimation</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="decimationSpinBox">
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>20</number>
-                   </property>
-                   <property name="value">
-                    <number>8</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_10">
-              <item>
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
          </layout>
-        </widget>
-        <widget class="QWidget" name="tab_15">
-         <attribute name="title">
-          <string>Terminal</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_21">
-          <item>
-           <widget class="QWidget" name="widget_2" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_4">
-             <item>
-              <widget class="QTextBrowser" name="terminalBrowser">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Monospace</family>
-                </font>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_15">
-               <item>
-                <widget class="QLineEdit" name="terminalEdit"/>
-               </item>
-               <item>
-                <widget class="QPushButton" name="sendTerminalButton">
-                 <property name="text">
-                  <string>Send</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="clearTerminalButton">
-                 <property name="text">
-                  <string>Clear</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_23">
-         <attribute name="title">
-          <string>Firmware</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_18">
-          <item>
-           <widget class="QGroupBox" name="groupBox_23">
-            <property name="title">
-             <string>Upload New Firmware</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_34">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_81">
-               <property name="text">
-                <string>Path</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="3">
-              <widget class="QPushButton" name="firmwareUploadButton">
-               <property name="text">
-                <string>Upload</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0" colspan="2">
-              <widget class="QLabel" name="firmwareUploadStatusLabel">
-               <property name="text">
-                <string>FW Upload Status</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" colspan="2">
-              <widget class="QProgressBar" name="firmwareBar">
-               <property name="maximum">
-                <number>1000</number>
-               </property>
-               <property name="value">
-                <number>0</number>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="firmwareEdit"/>
-             </item>
-             <item row="1" column="2">
-              <widget class="QPushButton" name="firmwareCancelButton">
-               <property name="text">
-                <string>Cancel</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2" colspan="2">
-              <widget class="QPushButton" name="firmwareChooseButton">
-               <property name="text">
-                <string>Choose...</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_26">
-            <property name="title">
-             <string>Firmware Version</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <item>
-              <widget class="QLabel" name="label_82">
-               <property name="text">
-                <string>Firmware version on connected VESC:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="firmwareVersionLabel">
-               <property name="text">
-                <string>X.Y</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_19">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="firmwareVersionReadButton">
-               <property name="text">
-                <string>Read Firmware Version</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_32">
-            <property name="title">
-             <string>Supported Firmwares (for this version of BLDC Tool)</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_42">
-             <item>
-              <widget class="QLabel" name="firmwareSupportedLabel">
-               <property name="text">
-                <string>X.Y</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_15">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>508</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_3">
-         <attribute name="title">
-          <string>Rotor Position</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_8">
-            <item row="0" column="0">
-             <widget class="QPushButton" name="detectButton">
-              <property name="text">
-               <string>Inductance</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="7">
-             <widget class="QPushButton" name="stopDetectButton">
-              <property name="text">
-               <string>Stop</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="4">
-             <widget class="QPushButton" name="detectPidPosErrorButton">
-              <property name="text">
-               <string>PID Pos Error</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="detectEncoderButton">
-              <property name="text">
-               <string>Encoder</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QPushButton" name="detectObserverButton">
-              <property name="text">
-               <string>Observer</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="5">
-             <widget class="QPushButton" name="detectEncoderObserverErrorButton">
-              <property name="text">
-               <string>Encoder Observer Error</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="6">
-             <spacer name="horizontalSpacer_36">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="3">
-             <widget class="QPushButton" name="detectPidPosButton">
-              <property name="text">
-               <string>PID Pos</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QProgressBar" name="rotorPosBar">
-            <property name="maximum">
-             <number>359</number>
-            </property>
-            <property name="value">
-             <number>120</number>
-            </property>
-            <property name="format">
-             <string>%v Degrees</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCustomPlot" name="realtimePlotPosition" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="tab_10">
-         <attribute name="title">
-          <string>Experiment</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_22">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-             <widget class="QLabel" name="experimentSampleLabel">
-              <property name="text">
-               <string>0 Samples</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="experimentClearSamplesButton">
-              <property name="text">
-               <string>Clear samples</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="experimentSaveSamplesButton">
-              <property name="text">
-               <string>Save samples to file...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTextBrowser" name="experimentBrowser"/>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_6">
-            <property name="title">
-             <string>Autosave Samples</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_11">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_13">
-               <item>
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>Path</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="experimentPathEdit"/>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_8">
-               <item>
-                <widget class="QCheckBox" name="experimentAutosaveBox">
-                 <property name="text">
-                  <string>Use autosave</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_13">
-                 <property name="text">
-                  <string>Autosave every</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="experimentAutosaveIntervalBox">
-                 <property name="maximum">
-                  <number>1000000</number>
-                 </property>
-                 <property name="value">
-                  <number>1000</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_15">
-                 <property name="text">
-                  <string>samples</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_35">
-            <property name="title">
-             <string>Servo Output</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QSlider" name="servoOutputSlider">
-               <property name="maximum">
-                <number>1000</number>
-               </property>
-               <property name="value">
-                <number>500</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="invertedAppearance">
-                <bool>false</bool>
-               </property>
-               <property name="invertedControls">
-                <bool>false</bool>
-               </property>
-               <property name="tickPosition">
-                <enum>QSlider::NoTicks</enum>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLCDNumber" name="servoOutputNumber">
-               <property name="digitCount">
-                <number>5</number>
-               </property>
-               <property name="value" stdset="0">
-                <double>0.500000000000000</double>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <widget class="QWidget" name="widget2" native="true">
-      <layout class="QVBoxLayout" name="verticalLayout_26">
-       <item>
-        <widget class="QToolBox" name="toolBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <widget class="QWidget" name="page">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>248</width>
-            <height>82</height>
-           </rect>
-          </property>
-          <attribute name="label">
-           <string>Serial Connection</string>
-          </attribute>
-          <layout class="QGridLayout" name="gridLayout_49">
-           <item row="0" column="0" colspan="2">
-            <widget class="QComboBox" name="serialCombobox">
+        </item>
+        <item>
+         <widget class="QWidget" name="widget2" native="true">
+          <layout class="QVBoxLayout" name="verticalLayout_26">
+           <item>
+            <widget class="QToolBox" name="toolBox">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="refreshButton">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+             <property name="currentIndex">
+              <number>0</number>
              </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="resources.qrc">
-               <normaloff>:/res/refresh.png</normaloff>:/res/refresh.png</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QPushButton" name="serialConnectButton">
-             <property name="text">
-              <string>Connect</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="page_2">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>248</width>
-            <height>82</height>
-           </rect>
-          </property>
-          <attribute name="label">
-           <string>UDP Connection</string>
-          </attribute>
-          <layout class="QGridLayout" name="gridLayout_50">
-           <item row="0" column="0">
-            <widget class="QLineEdit" name="udpIpEdit"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="udpConnectButton">
-             <property name="text">
-              <string>Connect</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_28">
-         <item row="0" column="0" colspan="2">
-          <widget class="QPushButton" name="disconnectButton">
-           <property name="text">
-            <string>Disconnect</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QPushButton" name="appconfRebootButton">
-           <property name="text">
-            <string>Reboot</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QSpinBox" name="canIdBox"/>
-         </item>
-         <item row="1" column="1" colspan="2">
-          <widget class="QCheckBox" name="canFwdBox">
-           <property name="text">
-            <string>CAN Fwd</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QTabWidget" name="tabWidget_6">
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <widget class="QWidget" name="tab_26">
-          <attribute name="title">
-           <string>Control</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <widget class="QGroupBox" name="groupBox_2">
-             <property name="title">
-              <string>Control</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QDoubleSpinBox" name="dutyBox">
-                <property name="minimum">
-                 <double>-1.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>1.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="dutyButton">
-                <property name="text">
-                 <string>Duty</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QSpinBox" name="rpmBox">
-                <property name="minimum">
-                 <number>-100000</number>
-                </property>
-                <property name="maximum">
-                 <number>100000</number>
-                </property>
-                <property name="singleStep">
-                 <number>1000</number>
-                </property>
-                <property name="value">
-                 <number>15000</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="rpmButton">
-                <property name="text">
-                 <string>RPM</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QDoubleSpinBox" name="currentBox">
-                <property name="suffix">
-                 <string> A</string>
-                </property>
-                <property name="decimals">
-                 <number>1</number>
-                </property>
-                <property name="minimum">
-                 <double>-200.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>200.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>3.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QPushButton" name="currentButton">
-                <property name="text">
-                 <string>Current</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QPushButton" name="currentBrakeButton">
-                <property name="text">
-                 <string>Brake</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QPushButton" name="posCtrlButton">
-                <property name="text">
-                 <string>Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QDoubleSpinBox" name="currentBrakeBox">
-                <property name="suffix">
-                 <string> A</string>
-                </property>
-                <property name="decimals">
-                 <number>1</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>200.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>3.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QDoubleSpinBox" name="posCtrlBox">
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QCheckBox" name="overrideKbBox">
-                <property name="text">
-                 <string>KB Ctrl</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="QDoubleSpinBox" name="arrowCurrentBox">
-                <property name="prefix">
-                 <string>I: </string>
-                </property>
-                <property name="suffix">
-                 <string> A</string>
-                </property>
-                <property name="decimals">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <double>200.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>3.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0" colspan="2">
-               <widget class="QPushButton" name="offBrakeButton">
-                <property name="text">
-                 <string>Full Brake</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="tab_27">
-          <attribute name="title">
-           <string>Plot and Sample</string>
-          </attribute>
-          <layout class="QVBoxLayout" name="verticalLayout_38">
-           <item>
-            <widget class="QGroupBox" name="groupBox">
-             <property name="title">
-              <string>BEMF and Current Sampling</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout">
-              <item>
-               <layout class="QGridLayout" name="gridLayout">
-                <item row="1" column="0">
-                 <widget class="QLabel" name="label">
-                  <property name="text">
-                   <string>Samples</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_2">
-                  <property name="text">
-                   <string>Decimation</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QSpinBox" name="sampleNumBox">
-                  <property name="minimum">
-                   <number>10</number>
-                  </property>
-                  <property name="maximum">
-                   <number>2000</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>100</number>
-                  </property>
-                  <property name="value">
-                   <number>1000</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QSpinBox" name="sampleFreqBox">
-                  <property name="minimum">
-                   <number>1</number>
-                  </property>
-                  <property name="maximum">
-                   <number>200000</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>1000</number>
-                  </property>
-                  <property name="value">
-                   <number>40000</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="1">
-                 <widget class="QSpinBox" name="sampleIntBox">
-                  <property name="minimum">
-                   <number>1</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="label_5">
-                  <property name="text">
-                   <string>Fs for FFT</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0">
-                 <widget class="QPushButton" name="getDataButton">
-                  <property name="text">
-                   <string>Now</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QPushButton" name="getDataStartButton">
-                  <property name="text">
-                   <string>At start</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
+             <widget class="QWidget" name="page">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>237</width>
+                <height>80</height>
+               </rect>
+              </property>
+              <attribute name="label">
+               <string>Serial Connection</string>
+              </attribute>
+              <layout class="QGridLayout" name="gridLayout_49">
+               <item row="0" column="0" colspan="2">
+                <widget class="QComboBox" name="serialCombobox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QPushButton" name="refreshButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="resources.qrc">
+                   <normaloff>:/res/refresh.png</normaloff>:/res/refresh.png</iconset>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QPushButton" name="serialConnectButton">
+                 <property name="text">
+                  <string>Connect</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="page_2">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>237</width>
+                <height>80</height>
+               </rect>
+              </property>
+              <attribute name="label">
+               <string>UDP Connection</string>
+              </attribute>
+              <layout class="QGridLayout" name="gridLayout_50">
+               <item row="0" column="0">
+                <widget class="QLineEdit" name="udpIpEdit"/>
+               </item>
+               <item row="1" column="0">
+                <widget class="QPushButton" name="udpConnectButton">
+                 <property name="text">
+                  <string>Connect</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_5">
-             <property name="title">
-              <string>Plot Control</string>
+            <layout class="QGridLayout" name="gridLayout_28">
+             <item row="0" column="0" colspan="2">
+              <widget class="QPushButton" name="disconnectButton">
+               <property name="text">
+                <string>Disconnect</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QPushButton" name="appconfRebootButton">
+               <property name="text">
+                <string>Reboot</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="canIdBox"/>
+             </item>
+             <item row="1" column="1" colspan="2">
+              <widget class="QCheckBox" name="canFwdBox">
+               <property name="text">
+                <string>CAN Fwd</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-             <layout class="QGridLayout" name="gridLayout_27">
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="horizontalZoomBox">
-                <property name="text">
-                 <string>HZoom</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QCheckBox" name="verticalZoomBox">
-                <property name="text">
-                 <string>VZoom</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QPushButton" name="rescaleButton">
-                <property name="text">
-                 <string>Rescale</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="replotButton">
-                <property name="text">
-                 <string>Replot</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <spacer name="verticalSpacer_19">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QTabWidget" name="tabWidget_6">
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <widget class="QWidget" name="tab_26">
+              <attribute name="title">
+               <string>Control</string>
+              </attribute>
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <item>
+                <widget class="QGroupBox" name="groupBox_2">
+                 <property name="title">
+                  <string>Control</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <item row="0" column="0">
+                   <widget class="QDoubleSpinBox" name="dutyBox">
+                    <property name="minimum">
+                     <double>-1.000000000000000</double>
+                    </property>
+                    <property name="maximum">
+                     <double>1.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>0.010000000000000</double>
+                    </property>
+                    <property name="value">
+                     <double>0.200000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QPushButton" name="dutyButton">
+                    <property name="text">
+                     <string>Duty</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QSpinBox" name="rpmBox">
+                    <property name="minimum">
+                     <number>-100000</number>
+                    </property>
+                    <property name="maximum">
+                     <number>100000</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>1000</number>
+                    </property>
+                    <property name="value">
+                     <number>15000</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QPushButton" name="rpmButton">
+                    <property name="text">
+                     <string>RPM</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QDoubleSpinBox" name="currentBox">
+                    <property name="suffix">
+                     <string> A</string>
+                    </property>
+                    <property name="decimals">
+                     <number>1</number>
+                    </property>
+                    <property name="minimum">
+                     <double>-200.000000000000000</double>
+                    </property>
+                    <property name="maximum">
+                     <double>200.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>0.500000000000000</double>
+                    </property>
+                    <property name="value">
+                     <double>3.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QPushButton" name="currentButton">
+                    <property name="text">
+                     <string>Current</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QPushButton" name="currentBrakeButton">
+                    <property name="text">
+                     <string>Brake</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QPushButton" name="posCtrlButton">
+                    <property name="text">
+                     <string>Position</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QDoubleSpinBox" name="currentBrakeBox">
+                    <property name="suffix">
+                     <string> A</string>
+                    </property>
+                    <property name="decimals">
+                     <number>1</number>
+                    </property>
+                    <property name="minimum">
+                     <double>0.000000000000000</double>
+                    </property>
+                    <property name="maximum">
+                     <double>200.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>0.500000000000000</double>
+                    </property>
+                    <property name="value">
+                     <double>3.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QDoubleSpinBox" name="posCtrlBox">
+                    <property name="decimals">
+                     <number>3</number>
+                    </property>
+                    <property name="maximum">
+                     <double>360.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0">
+                   <widget class="QCheckBox" name="overrideKbBox">
+                    <property name="text">
+                     <string>KB Ctrl</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="1">
+                   <widget class="QDoubleSpinBox" name="arrowCurrentBox">
+                    <property name="prefix">
+                     <string>I: </string>
+                    </property>
+                    <property name="suffix">
+                     <string> A</string>
+                    </property>
+                    <property name="decimals">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <double>200.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                     <double>0.500000000000000</double>
+                    </property>
+                    <property name="value">
+                     <double>3.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <widget class="QPushButton" name="offBrakeButton">
+                    <property name="text">
+                     <string>Full Brake</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="tab_27">
+              <attribute name="title">
+               <string>Plot and Sample</string>
+              </attribute>
+              <layout class="QVBoxLayout" name="verticalLayout_38">
+               <item>
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
+                  <string>BEMF and Current Sampling</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout">
+                  <item>
+                   <layout class="QGridLayout" name="gridLayout">
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="label">
+                      <property name="text">
+                       <string>Samples</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_2">
+                      <property name="text">
+                       <string>Decimation</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QSpinBox" name="sampleNumBox">
+                      <property name="minimum">
+                       <number>10</number>
+                      </property>
+                      <property name="maximum">
+                       <number>2000</number>
+                      </property>
+                      <property name="singleStep">
+                       <number>100</number>
+                      </property>
+                      <property name="value">
+                       <number>1000</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QSpinBox" name="sampleFreqBox">
+                      <property name="minimum">
+                       <number>1</number>
+                      </property>
+                      <property name="maximum">
+                       <number>200000</number>
+                      </property>
+                      <property name="singleStep">
+                       <number>1000</number>
+                      </property>
+                      <property name="value">
+                       <number>40000</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QSpinBox" name="sampleIntBox">
+                      <property name="minimum">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>Fs for FFT</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0">
+                     <widget class="QPushButton" name="getDataButton">
+                      <property name="text">
+                       <string>Now</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QPushButton" name="getDataStartButton">
+                      <property name="text">
+                       <string>At start</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_5">
+                 <property name="title">
+                  <string>Plot Control</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_27">
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="horizontalZoomBox">
+                    <property name="text">
+                     <string>HZoom</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QCheckBox" name="verticalZoomBox">
+                    <property name="text">
+                     <string>VZoom</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QPushButton" name="rescaleButton">
+                    <property name="text">
+                     <string>Rescale</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QPushButton" name="replotButton">
+                    <property name="text">
+                     <string>Replot</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <spacer name="verticalSpacer_19">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="offButton">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>15</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Release Motor (ESC)</string>
+             </property>
             </widget>
            </item>
           </layout>
          </widget>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="offButton">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>50</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>15</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Release Motor (ESC)</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
    </layout>
@@ -6386,22 +6411,6 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>currentFilterFreqBox</sender>
-   <signal>valueChanged(double)</signal>
-   <receiver>replotButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>465</x>
-     <y>673</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>1269</x>
-     <y>580</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>sampleFreqBox</sender>
    <signal>valueChanged(int)</signal>
    <receiver>replotButton</receiver>
@@ -6410,6 +6419,22 @@ p, li { white-space: pre-wrap; }
     <hint type="sourcelabel">
      <x>1268</x>
      <y>482</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1269</x>
+     <y>580</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>currentFilterFreqBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>replotButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>465</x>
+     <y>673</y>
     </hint>
     <hint type="destinationlabel">
      <x>1269</x>
@@ -6594,22 +6619,6 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>filterScatterBox2</sender>
-   <signal>clicked()</signal>
-   <receiver>replotButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>141</x>
-     <y>71</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>1269</x>
-     <y>580</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>showCurrent1Box</sender>
    <signal>clicked()</signal>
    <receiver>replotButton</receiver>
@@ -6618,6 +6627,22 @@ p, li { white-space: pre-wrap; }
     <hint type="sourcelabel">
      <x>78</x>
      <y>571</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1269</x>
+     <y>580</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>filterScatterBox2</sender>
+   <signal>clicked()</signal>
+   <receiver>replotButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>141</x>
+     <y>71</y>
     </hint>
     <hint type="destinationlabel">
      <x>1269</x>
@@ -6786,22 +6811,6 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>currentTimeButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>replotButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>885</x>
-     <y>573</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>1269</x>
-     <y>580</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>terminalEdit</sender>
    <signal>returnPressed()</signal>
    <receiver>sendTerminalButton</receiver>
@@ -6814,6 +6823,22 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>898</x>
      <y>711</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>currentTimeButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>replotButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>885</x>
+     <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1269</x>
+     <y>580</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
- Added a scrollArea as child of centralWidget and moved every child of centralWidget into the content-widget of the scroll area,
  reapplied horizontal Layout.
- Disabled horizontal scrolling.

Tests:
- Tested with the key control of motor. No effects on this, motor can still be controlled via the up/down key.

Additional unexpected features:
- You now can choose the option "Maximize" in your graphical desktop (was disabled before in Gnome)

Fixes #16