### PR TITLE
fixed 4 delete[]'s

### DIFF
--- a/digitalfiltering.cpp
+++ b/digitalfiltering.cpp
@@ -135,8 +135,8 @@ void DigitalFiltering::dft(int dir, int len, double *real, double *imag) {
         }
     }
 
-    delete x2;
-    delete y2;
+    delete[] x2;
+    delete[] y2;
 }
 
 void DigitalFiltering::fftshift(double *data, int len)
@@ -298,8 +298,8 @@ QVector<double> DigitalFiltering::fftWithShift(QVector<double> &signal, int resu
         result.append(fabs(signal_vector[i]) / div_factor);
     }
 
-    delete signal_vector;
-    delete imag;
+    delete[] signal_vector;
+    delete[] imag;
 
     return result;
 }


### PR DESCRIPTION
fixed 4 instances of new[] allocated pointers being freed by delete instead of delete[]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vedderb/bldc-tool/18)
<!-- Reviewable:end -->
