### PR TITLE
Add Fedora/CentOS to Build Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ ui_*
 Makefile
 BLDC_Tool.app
 BLDC_Tool
+.qmake.stash
+qrc_resources.cpp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-A Qt gui to control and debug my custom BLDC controller. A complete description and tutorial about how to use it can be found here: http://vedder.se/2015/01/vesc-open-source-esc/
+BLDC Tool
+=========
 
-Quick build instructions for Ubuntu:
+A [Qt](https://www.qt.io/) GUI to control and debug my custom BLDC controller. A complete description and tutorial about how to use it [can be found here.](http://vedder.se/2015/01/vesc-open-source-esc/)
+
+### Quick build instructions for [Ubuntu](https://www.ubuntu.com/):
 
 1. `sudo apt-get install qtcreator qt-sdk libudev-dev libqt5serialport5-dev`
 
@@ -14,6 +17,16 @@ Quick build instructions for Ubuntu:
 
 6. Start BLDC-tool from inside of the built repo `./BLDC_Tool`
 
-Windows and OS X builds available :
+### Quick build instructions for [Fedora](https://getfedora.org/)/[CentOS](https://www.centos.org/):
 
-https://bldc-tool.support
+1. `sudo dnf install qtcreator qt-devel qt5-qtserialport-devel`
+
+2. `qmake-qt5`
+
+3. `make clean && make`
+
+4. Allow for serial access without using sudo: `sudo usermod -a -G dialout $USER`
+
+5. Restart for access changes to take effect `sudo reboot now`
+
+6. Start BLDC-tool from inside of the built repo `./BLDC_Tool`


### PR DESCRIPTION
Updated README with build instructions for Fedora and tweaked the formatting to be a little more friendly. Also added a couple build artifacts to gitignore.

Removed the broken link as well, I can update that to a more current link if one exists right now.

This is kind of a drive by pull request, so let me know if you want me to change anything!